### PR TITLE
Float v2.0c: Fix ATR speed boost bug causing it to be disabled below 40%

### DIFF
--- a/float/float/float.c
+++ b/float/float/float.c
@@ -477,7 +477,7 @@ static void configure(data *d) {
 
 	// Feature: ATR:
 	d->float_acc_diff = 0;
-	d->atr_speed_boost_multiplier = 1 / 3000;  // used to be hard coded to 3000, still is for speed_boost <= 40%
+	d->atr_speed_boost_multiplier = 1.0 / 3000.0;  // used to be hard coded to 3000, still is for speed_boost <= 40%
 	if (fabsf(d->float_conf.atr_speed_boost) > 0.4) {
 		// above 0.4 we add 500erpm for each extra 10% of speed boost, so at most +6000 for 100% speed boost
 		// we're producing a multiplier here to avoid unnecessary floating point division in the main loop

--- a/float/ui.qml.in
+++ b/float/ui.qml.in
@@ -702,7 +702,7 @@ Item {
 					}
 					Text {
 						id: versionText
-						text: "{{VERSION}}.0b"
+						text: "{{VERSION}}.0c"
 						color: Utility.getAppHexColor("lightText")
 						font.pointSize: 10
 						font.weight: Font.Black


### PR DESCRIPTION
Thanks to riddimrider for spotting this bug!

Signed-off-by: Dado Mista <dadomista@gmail.com>
