### PR TITLE
Remove the separate Float package loop frequency setting.

### DIFF
--- a/c_libs/rules.mk
+++ b/c_libs/rules.mk
@@ -37,7 +37,12 @@ CFLAGS += -I$(STLIB_PATH)/CMSIS/include -I$(STLIB_PATH)/CMSIS/ST -I$(UTILS_PATH)
 CFLAGS += -fomit-frame-pointer -falign-functions=16 -mthumb
 CFLAGS += -fsingle-precision-constant -Wdouble-promotion
 CFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mcpu=cortex-m4
-CFLAGS += -fdata-sections -ffunction-sections
+# Individual data and function sections don't work with "-g" option
+ifndef DEBUG_BUILD
+	CFLAGS += -fdata-sections -ffunction-sections
+else
+	CFLAGS += -g
+endif
 CFLAGS += -DIS_VESC_LIB
 CFLAGS += $(USE_OPT)
 

--- a/c_libs/vesc_c_if.h
+++ b/c_libs/vesc_c_if.h
@@ -207,6 +207,7 @@ typedef bool (*load_extension_fptr)(char*,extension_fptr);
 
 typedef void* lib_thread;
 typedef void* lib_mutex;
+typedef void* lib_semaphore;
 
 typedef enum {
 	VESC_PIN_COMM_RX = 0,
@@ -275,6 +276,25 @@ typedef enum {
 	CFG_PARAM_IMU_rot_roll,
 	CFG_PARAM_IMU_rot_pitch,
 	CFG_PARAM_IMU_rot_yaw,
+	CFG_PARAM_IMU_ahrs_mode,
+	CFG_PARAM_IMU_sample_rate,
+	CFG_PARAM_IMU_accel_offset_x,
+	CFG_PARAM_IMU_accel_offset_y,
+	CFG_PARAM_IMU_accel_offset_z,
+	CFG_PARAM_IMU_gyro_offset_x,
+	CFG_PARAM_IMU_gyro_offset_y,
+	CFG_PARAM_IMU_gyro_offset_z,
+
+	CFG_PARAM_app_shutdown_mode,
+
+	// Motor Additional Info
+	CFG_PARAM_si_motor_poles,
+	CFG_PARAM_si_gear_ratio,
+	CFG_PARAM_si_wheel_diameter,
+	CFG_PARAM_si_battery_type,
+	CFG_PARAM_si_battery_cells,
+	CFG_PARAM_si_battery_ah,
+	CFG_PARAM_si_motor_nl_current,
 } CFG_PARAM;
 
 typedef struct {
@@ -313,7 +333,7 @@ typedef struct {
 
 	lbm_value (*lbm_enc_i)(lbm_int x);
 	lbm_value (*lbm_enc_u)(lbm_uint x);
-	lbm_value (*lbm_enc_char)(char x);
+	lbm_value (*lbm_enc_char)(uint8_t x);
 	lbm_value (*lbm_enc_float)(float f);
 	lbm_value (*lbm_enc_u32)(uint32_t u);
 	lbm_value (*lbm_enc_i32)(int32_t i);
@@ -322,7 +342,7 @@ typedef struct {
 	float (*lbm_dec_as_float)(lbm_value val);
 	uint32_t (*lbm_dec_as_u32)(lbm_value val);
 	int32_t (*lbm_dec_as_i32)(lbm_value val);
-	char (*lbm_dec_char)(lbm_value x);
+	uint8_t (*lbm_dec_char)(lbm_value x);
 	char* (*lbm_dec_str)(lbm_value);
 	lbm_uint (*lbm_dec_sym)(lbm_value x);
 
@@ -533,7 +553,7 @@ typedef struct {
 	volatile gnss_data* (*mc_gnss)(void);
 
 	// Mutex
-	lib_mutex (*mutex_create)(void);
+	lib_mutex (*mutex_create)(void); // Use VESC_IF->free on the mutex when done with it
 	void (*mutex_lock)(lib_mutex);
 	void (*mutex_unlock)(lib_mutex);
 
@@ -592,6 +612,50 @@ typedef struct {
 	void (*foc_set_openloop_phase)(float current, float phase);
 	void (*foc_set_openloop_duty)(float dutyCycle, float rpm);
 	void (*foc_set_openloop_duty_phase)(float dutyCycle, float phase);
+
+	// Functions below were added in firmware 6.05
+
+	// Flat values
+	bool (*lbm_start_flatten)(lbm_flat_value_t *v, size_t buffer_size);
+	bool (*lbm_finish_flatten)(lbm_flat_value_t *v);
+	bool (*f_cons)(lbm_flat_value_t *v);
+	bool (*f_sym)(lbm_flat_value_t *v, lbm_uint sym);
+	bool (*f_i)(lbm_flat_value_t *v, lbm_int i);
+	bool (*f_b)(lbm_flat_value_t *v, uint8_t b);
+	bool (*f_i32)(lbm_flat_value_t *v, int32_t w);
+	bool (*f_u32)(lbm_flat_value_t *v, uint32_t w);
+	bool (*f_float)(lbm_flat_value_t *v, float f);
+	bool (*f_i64)(lbm_flat_value_t *v, int64_t w);
+	bool (*f_u64)(lbm_flat_value_t *v, uint64_t w);
+	bool (*f_lbm_array)(lbm_flat_value_t *v, uint32_t num_elts, uint8_t *data);
+
+	// Unblock unboxed
+	bool (*lbm_unblock_ctx_unboxed)(lbm_cid cid, lbm_value unboxed);
+
+	// Time since boot in system ticks. Resolution: 100 uS.
+	// Use ts_to_age_s to get the age of a timestamp in
+	// seconds. ts_to_age_s should handle overflows.
+	systime_t (*system_time_ticks)(void);
+	void (*sleep_ticks)(systime_t ticks);
+
+	// FOC Audio
+	bool (*foc_beep)(float freq, float time, float voltage);
+	bool (*foc_play_tone)(int channel, float freq, float voltage);
+	void (*foc_stop_audio)(bool reset);
+	bool (*foc_set_audio_sample_table)(int channel, float *samples, int len);
+	const float* (*foc_get_audio_sample_table)(int channel);
+	bool (*foc_play_audio_samples)(const int8_t *samples, int num_samp, float f_samp, float voltage);
+
+	// Semaphores
+	lib_semaphore (*sem_create)(void); // Use VESC_IF->free on the semaphore when done with it
+	void (*sem_wait)(lib_semaphore);
+	void (*sem_signal)(lib_semaphore);
+	bool (*sem_wait_to)(lib_semaphore, systime_t); // Returns false on timeout
+	void (*sem_reset)(lib_semaphore);
+	int32_t (*sem_drain_and_wait_timeout)(lib_semaphore, systime_t);
+
+	// Os continued
+	systime_t (*time_to_ticks)(uint32_t seconds, uint32_t millis, uint32_t micros);
 } vesc_c_if;
 
 typedef struct {

--- a/float/float/conf/conf_default.h
+++ b/float/float/conf/conf_default.h
@@ -33,11 +33,6 @@
 #define APPCONF_FLOAT_KP2_BRAKE 1
 #endif
 
-// Loop Hertz
-#ifndef APPCONF_FLOAT_HERTZ
-#define APPCONF_FLOAT_HERTZ 832
-#endif
-
 // Pitch Axis Fault Cutoff
 #ifndef APPCONF_FLOAT_FAULT_PITCH
 #define APPCONF_FLOAT_FAULT_PITCH 60

--- a/float/float/conf/confparser.c
+++ b/float/float/conf/confparser.c
@@ -16,7 +16,6 @@ int32_t confparser_serialize_float_config(uint8_t *buffer, const float_config *c
 	buffer_append_float16(buffer, conf->mahony_kp, 100, &ind);
 	buffer_append_float16(buffer, conf->kp_brake, 10, &ind);
 	buffer_append_float16(buffer, conf->kp2_brake, 10, &ind);
-	buffer_append_uint16(buffer, conf->hertz, &ind);
 	buffer_append_float16(buffer, conf->fault_pitch, 10, &ind);
 	buffer_append_float16(buffer, conf->fault_roll, 10, &ind);
 	buffer_append_float16(buffer, conf->fault_adc1, 1000, &ind);
@@ -149,7 +148,6 @@ bool confparser_deserialize_float_config(const uint8_t *buffer, float_config *co
 	conf->mahony_kp = buffer_get_float16(buffer, 100, &ind);
 	conf->kp_brake = buffer_get_float16(buffer, 10, &ind);
 	conf->kp2_brake = buffer_get_float16(buffer, 10, &ind);
-	conf->hertz = buffer_get_uint16(buffer, &ind);
 	conf->fault_pitch = buffer_get_float16(buffer, 10, &ind);
 	conf->fault_roll = buffer_get_float16(buffer, 10, &ind);
 	conf->fault_adc1 = buffer_get_float16(buffer, 1000, &ind);
@@ -275,7 +273,6 @@ void confparser_set_defaults_float_config(float_config *conf) {
 	conf->mahony_kp = APPCONF_FLOAT_MAHONY_KP;
 	conf->kp_brake = APPCONF_FLOAT_KP_BRAKE;
 	conf->kp2_brake = APPCONF_FLOAT_KP2_BRAKE;
-	conf->hertz = APPCONF_FLOAT_HERTZ;
 	conf->fault_pitch = APPCONF_FLOAT_FAULT_PITCH;
 	conf->fault_roll = APPCONF_FLOAT_FAULT_ROLL;
 	conf->fault_adc1 = APPCONF_FLOAT_FAULT_ADC1;

--- a/float/float/conf/confparser.h
+++ b/float/float/conf/confparser.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 
 // Constants
-#define FLOAT_CONFIG_SIGNATURE		3424349568
+#define FLOAT_CONFIG_SIGNATURE		693252829
 
 // Functions
 int32_t confparser_serialize_float_config(uint8_t *buffer, const float_config *conf);

--- a/float/float/conf/datatypes.h
+++ b/float/float/conf/datatypes.h
@@ -50,7 +50,6 @@ typedef struct {
 	float kp_brake;
 	float kp2_brake;
 	uint16_t kp_brake_erpm;
-	uint16_t hertz;
 	float fault_pitch;
 	float fault_roll;
 	float fault_adc1;

--- a/float/float/conf/settings.xml
+++ b/float/float/conf/settings.xml
@@ -186,30 +186,6 @@ p, li { white-space: pre-wrap; }
             <suffix>x</suffix>
             <vTx>7</vTx>
         </kp2_brake>
-        <hertz>
-            <longName>Loop Hertz</longName>
-            <type>2</type>
-            <transmittable>1</transmittable>
-            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Frequency of Balance Loop Cycle&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600; text-decoration: underline;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Recommended Value: Same or multiple of IMU Sample Rate&lt;/span&gt;&lt;/p&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; font-style:italic;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Little FOCer v3.1 (LSM6DS3): 832Hz&lt;/li&gt;
-&lt;li style=&quot; font-style:italic;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Little FOCer v3 (BMI160): 800Hz&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</description>
-            <cDefine>APPCONF_FLOAT_HERTZ</cDefine>
-            <editorScale>1</editorScale>
-            <editAsPercentage>0</editAsPercentage>
-            <maxInt>4000</maxInt>
-            <minInt>50</minInt>
-            <showDisplay>0</showDisplay>
-            <stepInt>16</stepInt>
-            <valInt>832</valInt>
-            <suffix> Hz</suffix>
-            <vTx>3</vTx>
-        </hertz>
         <fault_pitch>
             <longName>Pitch Axis Fault Cutoff</longName>
             <type>1</type>
@@ -2668,7 +2644,6 @@ p, li { white-space: pre-wrap; }
         <ser>mahony_kp</ser>
         <ser>kp_brake</ser>
         <ser>kp2_brake</ser>
-        <ser>hertz</ser>
         <ser>fault_pitch</ser>
         <ser>fault_roll</ser>
         <ser>fault_adc1</ser>
@@ -2972,8 +2947,6 @@ p, li { white-space: pre-wrap; }
                     <param>::sep::Float Package Details</param>
                     <param>float_version</param>
                     <param>float_disable</param>
-                    <param>::sep::Balance Loop</param>
-                    <param>hertz</param>
                     <param>::sep::Voltage Tiltbacks</param>
                     <param>tiltback_hv</param>
                     <param>tiltback_lv</param>


### PR DESCRIPTION
The frequency is now acquired from IMU app directly. Also implement semaphore-based synchronization between the IMU update thread and Float thread which reduces the jitter and tightens the response time of Float package.

Some housekeeping in this PR as well - sync the vesc_pkg vesc_c_if.h with the BLDC one.

Tested this change, my Floatweel rode fine. Package installation and uninstall also works fine.

This PR goes hand-in-hand with the another one I created against vedderb/bldc that adds
two new functions to `VESC_IF`.