### PR TITLE
Fix -M parameter

### DIFF
--- a/dash35b/font/generate_fonts
+++ b/dash35b/font/generate_fonts
@@ -1,3 +1,2 @@
 #!/bin/bash
-lbm -H 100000 -M 11 -C 1000000 -s make_fonts.lbm --terminate
-
+lbm -H 100000 -M 262144 -C 1000000 -s make_fonts.lbm --terminate


### PR DESCRIPTION
In the current version of the lispbm repl/lbm, this flag is no longer a lookup table, but the number of bytes to allocate. I've swapped the old lookup value for it's corresponding bytes value.