### PR TITLE
Fix errors caused by the switch to VESC 7.00.

### DIFF
--- a/blacktip_dpv/DEVELOPMENT.md
+++ b/blacktip_dpv/DEVELOPMENT.md
@@ -35,7 +35,7 @@ This document contains information for developers working on the BlackTip DPV VE
 
 VESC firmware 7.00 introduced a persistent flash heap using `@const-start` / `@const-end` blocks that replaces the older `move-to-flash` pattern. The runtime is structured as two const blocks with mutable state defined between them:
 
-```
+```lisp
 @const-start       ; Block 1: constants and the debug-logging macro (flashed, immutable)
   (define SLEEP_STATE_MACHINE …)
   …
@@ -102,11 +102,13 @@ This bug only affects the first transaction on a freshly muxed bus. Subsequent c
 
 The project uses GNU Make for building the VESC package:
 
-    make              # Build blacktip_dpv.vescpkg
-    make clean        # Remove generated files
-    make test         # Run code quality checks and smoke tests
-    make smoke-tests  # Run unit-style smoke tests only
-    make binary       # Generate binary LUT files only
+```text
+make              # Build blacktip_dpv.vescpkg
+make clean        # Remove generated files
+make test         # Run code quality checks and smoke tests
+make smoke-tests  # Run unit-style smoke tests only
+make binary       # Generate binary LUT files only
+```
 
 ### Version Management
 
@@ -133,7 +135,9 @@ To update the version:
 
 The project includes smoke tests for pure functions to catch regressions before flashing hardware:
 
-    make smoke-tests  # Run 30+ unit tests for pure functions
+```text
+make smoke-tests  # Run 30+ unit tests for pure functions
+```
 
 **Tested functions:**
 
@@ -174,16 +178,18 @@ This CSV file is the source of truth. The build system automatically generates t
 
 Visualize and verify display artwork before building:
 
-    // List all available screens
-    python tools/preview_display.py --list
-    // Preview a specific frame by index
-    python tools/preview_display.py --index 0
-    // Preview by name and rotation
-    python tools/preview_display.py --name "Display Battery 4 Bars" --rotation 0
-    // Show all screens for a given rotation
-    python tools/preview_display.py --show-all-rotation 0
-    // Export as PGM image
-    python tools/preview_display.py --index 0 --output preview.pgm
+```text
+// List all available screens
+python tools/preview_display.py --list
+// Preview a specific frame by index
+python tools/preview_display.py --index 0
+// Preview by name and rotation
+python tools/preview_display.py --name "Display Battery 4 Bars" --rotation 0
+// Show all screens for a given rotation
+python tools/preview_display.py --show-all-rotation 0
+// Export as PGM image
+python tools/preview_display.py --index 0 --output preview.pgm
+```
 
 The preview tool applies the correct 90° clockwise rotation and vertical flip to match the physical hardware orientation.
 
@@ -228,7 +234,9 @@ Each display frame consists of:
 
 ### Testing
 
-    make test  # Runs whitespace checks
+```text
+make test  # Runs whitespace checks
+```
 
 ### Code Style
 
@@ -248,11 +256,15 @@ Two mechanisms are available for debug logging:
 
 **`debug_log` function** - For static strings:
 
-    (debug_log "Motor: Stopping motor")
+```lisp
+(debug_log "Motor: Stopping motor")
+```
 
 **`debug_log_format` macro** - For dynamic strings with expensive operations:
 
-    (debug_log_format (str-merge "Speed: Set to " (to-str clamped_speed)))
+```lisp
+(debug_log_format (str-merge "Speed: Set to " (to-str clamped_speed)))
+```
 
 ### When to Use `debug_log_format`
 
@@ -275,11 +287,15 @@ The macro only evaluates these expressions when `debug_enabled` is 1, preventing
 
 **Bad** (evaluates `str-merge` even when debug is off):
 
-    (debug_log (str-merge "Speed: Set to " (to-str speed)))
+```lisp
+(debug_log (str-merge "Speed: Set to " (to-str speed)))
+```
 
 **Good** (only evaluates when debug is enabled):
 
-    (debug_log_format (str-merge "Speed: Set to " (to-str speed)))
+```lisp
+(debug_log_format (str-merge "Speed: Set to " (to-str speed)))
+```
 
 ## Testing Best Practices
 
@@ -297,6 +313,10 @@ When adding new pure functions (functions without side effects), add correspondi
 * Error conditions
 
 4. **Run tests before committing**:
+
+```text
+make test
+```
 
 ### What to Test
 
@@ -317,36 +337,42 @@ Each test function should:
 
 Example:
 
-    def test_new_function():
-        print("\n=== Testing new_function ===")
-        assert_eq(new_function(5), 10, "new_function: basic case")
-        assert_eq(new_function(0), 0, "new_function: zero input")
-        assert_eq(new_function(-1), 0, "new_function: negative clamped")
+```text
+def test_new_function():
+    print("\n=== Testing new_function ===")
+    assert_eq(new_function(5), 10, "new_function: basic case")
+    assert_eq(new_function(0), 0, "new_function: zero input")
+    assert_eq(new_function(-1), 0, "new_function: negative clamped")
+```
 
 ## Binary Loading Implementation
 
 The runtime uses LispBM's `import` statement to load binary data at runtime:
 
-    ; Import binary file as a top-level form (NOT inside a flashed function — see VESC 7.00 notes)
-    (import "generated/display_lut.bin" 'display_lut_bin)
-    ; Validate headers
-    (defun validate_lut_header (data magic expected_version) { … })
-    ; Access display data (offset by 8-byte header)
-    (bufcpy pixbuf 0 display_lut_bin (+ 8 start_pos) 16)
+```lisp
+; Import binary file as a top-level form (NOT inside a flashed function — see VESC 7.00 notes)
+(import "generated/display_lut.bin" 'display_lut_bin)
+; Validate headers
+(defun validate_lut_header (data magic expected_version) { … })
+; Access display data (offset by 8-byte header)
+(bufcpy pixbuf 0 display_lut_bin (+ 8 start_pos) 16)
+```
 
 ### Why `pixbuf` is Required
 
 The `pixbuf` variable is a 16-byte working buffer that is essential to the display system and **cannot be removed**:
 
-    (let ((start_pos 0)
-             (pixbuf (array-create 16))) {  // Temporary 16-byte buffer
-          …
-          // Copy 16 bytes from binary file to pixbuf
-          (bufcpy pixbuf 0 display_lut_bin (+ 8 start_pos) 16)
+```lisp
+(let ((start_pos 0)
+         (pixbuf (array-create 16))) {  // Temporary 16-byte buffer
+      …
+      // Copy 16 bytes from binary file to pixbuf
+      (bufcpy pixbuf 0 display_lut_bin (+ 8 start_pos) 16)
 
-          // Send pixbuf to display via I2C
-          (i2c-tx-rx mpu-addr pixbuf)
-    })
+      // Send pixbuf to display via I2C
+      (i2c-tx-rx mpu-addr pixbuf)
+})
+```
 
 **Why it's needed:**
 

--- a/blacktip_dpv/DEVELOPMENT.md
+++ b/blacktip_dpv/DEVELOPMENT.md
@@ -29,6 +29,75 @@ For more details, see the sections below and refer to `blacktip_dpv.lisp` for im
 
 This document contains information for developers working on the BlackTip DPV VESC package.
 
+## VESC 7.00 Compatibility
+
+### Flash / Heap Layout Strategy
+
+VESC firmware 7.00 introduced a persistent flash heap using `@const-start` / `@const-end` blocks that replaces the older `move-to-flash` pattern. The runtime is structured as two const blocks with mutable state defined between them:
+
+```
+@const-start       ; Block 1: constants and the debug-logging macro (flashed, immutable)
+  (define SLEEP_STATE_MACHINE …)
+  …
+  (define debug_log_format …)
+@const-end
+
+; MUTABLE GLOBAL STATE — heap-resident (NOT flashed), so setvar/set works at runtime.
+(define sw_state 0)
+…
+
+(import "generated/display_lut.bin" 'display_lut_bin)
+
+@const-start       ; Block 2: all functions (flashed, immutable)
+  (defun eeprom_store_i_if_changed …)
+  …
+@const-end
+
+; Boot sequence: init, then (progn (image-save) (main)) as a single top-level form.
+(init)
+(progn
+    (image-save)
+    (main))
+```
+
+**Rules that govern this layout:**
+
+**(a) Mutable globals must live outside the const blocks.**
+Flashed bindings are immutable. Every variable written at runtime via `setvar` or `set` must be defined on the working heap, between the two const blocks. These heap globals are pre-defined at the top level so their initialisers can reference already-flashed constants.
+
+**(b) Const-block initialisers are evaluated in source order.**
+A constant that references an earlier constant (e.g. `SOFT_START_DURATION` referencing `SAFE_START_TIMEOUT`) must come after it in the file. Function bodies have no such ordering constraint; LispBM resolves symbols at call time, not at definition time.
+
+**(c) Hardware init runs on every boot.**
+`image-save` does not restore external hardware state. All hardware initialisation (`i2c-start`, `gpio-configure`, oscillator setup) must live in the `init` / `main` call path so it re-executes on each cold boot.
+
+**(d) `import` must be a top-level form, not inside a flashed function.**
+When an `import` lives inside a flashed const-block function, the binding action is lost on subsequent boots; the imported symbol resolves to `nil`, causing `bufget-u32` type errors at runtime. The `import` for `display_lut.bin` is therefore placed as a top-level form between the two const blocks, where it runs once each time the package source is evaluated.
+
+**(e) `image-save` and `main` must be wrapped in a single `(progn …)` form.**
+`image-save` relocates the heap and serialises the environment, which invalidates the reader's source channel. If `image-save` and `main` are separate top-level forms, the reader tries to read `main` from the channel after `image-save` has run and fails with `read_error / ~CHANNEL~`. Wrapping both in one `(progn …)` means the entire form is parsed first, then `image-save` and `main` execute back-to-back with no intervening read.
+
+**(f) On subsequent boots the saved image is loaded and `main` is auto-invoked.**
+Only `init` runs from source on the very first boot after a fresh package upload. From the second boot onwards, the saved image is restored and `main` is invoked directly, bypassing the reader entirely.
+
+### VESC 7.00 Known Bugs and Workarounds
+
+#### I2C First-Message Bug
+
+On VESC firmware 7.00, the first `i2c-tx-rx` call issued after `i2c-start` — i.e. the first transaction on a freshly muxed bus, which happens on every cold boot — is silently swallowed and never reaches the I2C device.
+
+**Effect on cold boot:** The HT16K33 display controller's oscillator-enable command (`0x21`) was dropped on every cold boot. The oscillator never started, so the display chip stayed dormant and the screen remained dark. On firmware 6.06 the same single `0x21` was delivered correctly and the panel lit up.
+
+**Workaround:** Send the oscillator-enable command twice. The first write is sacrificial (absorbed by the firmware bug); the second is delivered to the controller.
+
+```lisp
+(i2c-tx-rx 0x70 (list 0x21)) ; sacrificial — absorbs the dropped first transaction
+(i2c-tx-rx 0x70 (list 0x21)) ; real oscillator-enable, reaches the HT16K33
+(i2c-tx-rx 0x70 (list 0x81)) ; display ON, blink off
+```
+
+This bug only affects the first transaction on a freshly muxed bus. Subsequent commands on the same bus configuration are delivered normally. The second display controller (`0x71` on CudaX) does not need the doubled command because by the time it is initialised the bus is already exercised by the `0x70` sequence.
+
 ## Build System
 
 The project uses GNU Make for building the VESC package:
@@ -181,13 +250,13 @@ Two mechanisms are available for debug logging:
 
     (debug_log "Motor: Stopping motor")
 
-**`when-debug` macro** - For dynamic strings with expensive operations:
+**`debug_log_format` macro** - For dynamic strings with expensive operations:
 
-    (when-debug (str-merge "Speed: Set to " (to-str clamped_speed)))
+    (debug_log_format (str-merge "Speed: Set to " (to-str clamped_speed)))
 
-### When to Use `when-debug`
+### When to Use `debug_log_format`
 
-Use the `when-debug` macro when logging requires:
+Use the `debug_log_format` macro when logging requires:
 
 * String concatenation (`str-merge`)
 * Number-to-string conversion (`to-str`)
@@ -195,7 +264,7 @@ Use the `when-debug` macro when logging requires:
 
 The macro only evaluates these expressions when `debug_enabled` is 1, preventing unnecessary memory allocation and CPU cycles in hot paths.
 
-### Hot Paths Requiring `when-debug`
+### Hot Paths Requiring `debug_log_format`
 
 * `set_speed_safe` - Called every speed change (multiple times per second)
 * Motor control loop - Runs continuously
@@ -210,7 +279,7 @@ The macro only evaluates these expressions when `debug_enabled` is 1, preventing
 
 **Good** (only evaluates when debug is enabled):
 
-    (when-debug (str-merge "Speed: Set to " (to-str speed)))
+    (debug_log_format (str-merge "Speed: Set to " (to-str speed)))
 
 ## Testing Best Practices
 
@@ -258,12 +327,12 @@ Example:
 
 The runtime uses LispBM's `import` statement to load binary data at runtime:
 
-    ; Import binary files
-    (import "generated/display_lut.bin" 'display-lut-bin)
+    ; Import binary file as a top-level form (NOT inside a flashed function — see VESC 7.00 notes)
+    (import "generated/display_lut.bin" 'display_lut_bin)
     ; Validate headers
-    (defun validate-lut-header (data magic expected-version) { ... })
+    (defun validate_lut_header (data magic expected_version) { … })
     ; Access display data (offset by 8-byte header)
-    (bufcpy pixbuf 0 display-lut-bin (+ 8 start_pos) 16)
+    (bufcpy pixbuf 0 display_lut_bin (+ 8 start_pos) 16)
 
 ### Why `pixbuf` is Required
 
@@ -271,9 +340,9 @@ The `pixbuf` variable is a 16-byte working buffer that is essential to the displ
 
     (let ((start_pos 0)
              (pixbuf (array-create 16))) {  // Temporary 16-byte buffer
-          ...
+          …
           // Copy 16 bytes from binary file to pixbuf
-          (bufcpy pixbuf 0 display-lut-bin (+ 8 start_pos) 16)
+          (bufcpy pixbuf 0 display_lut_bin (+ 8 start_pos) 16)
 
           // Send pixbuf to display via I2C
           (i2c-tx-rx mpu-addr pixbuf)

--- a/blacktip_dpv/README.md
+++ b/blacktip_dpv/README.md
@@ -2,7 +2,7 @@
 
 ![Blacktip DPV Logo](https://raw.githubusercontent.com/vedderb/vesc_pkg/main/blacktip_dpv/assets/shark_with_laser.png)
 
-**Version:** 1.3.0
+**Version:** 1.3.1
 
 ## License
 
@@ -37,6 +37,13 @@ Some videos showing the basic commands to control Smart Cruise while diving:
 - [manually enabling and disabling Smart Cruise](https://youtu.be/riwqB_mttLM)
 
 ---
+
+## What's New in Version 1.3.1
+
+Compatibility fix release for VESC firmware 7.00:
+
+- **Fix: Cold-boot dark display** — The display stayed completely dark after power-cycling the scooter. Root cause: VESC firmware 7.00 has a bug where the first I2C message sent after the bus is initialised on a cold boot is silently dropped. The HT16K33 display controller never received its oscillator-enable command and stayed dormant. Fixed by sending the oscillator-enable command twice at startup; the first write is absorbed by the firmware bug, the second reaches the controller.
+- **Fix: Package crash on second and subsequent boots** — VESC 7.00 re-evaluates package source on every boot but persists the flash heap from the previous session. The previous `move-to-flash` approach conflicted with this and caused an abort before any threads were spawned, leaving the display dark and the motor unresponsive. Switched to the `@const-start` / `@const-end` block syntax, which is the correct mechanism for VESC 7.00 and later.
 
 ## What's New in Version 1.3.0
 
@@ -181,9 +188,9 @@ Full access to all features via the VESC mobile app on iOS or Android devices:
 - Visual interface for speed configuration and feature toggles
 - Save settings directly to the scooter
 
-### Latest VESC Firmware (6.06) Compatibility
+### Latest VESC Firmware (7.00) Compatibility
 
-- Always compatible with the latest VESC firmware releases
+- Compatible with VESC firmware 7.00 and later
 - Benefits from continuous VESC ecosystem improvements
 - Ensures optimal motor control and efficiency
 - Silent, smooth operation with latest FOC algorithms
@@ -233,7 +240,7 @@ This package includes substantial improvements over the original [V1.50 Dive Xtr
 
 ### General Improvements
 
-- ✅ **Runs on the latest (6.06) VESC release** — Smoother running with latest FOC algorithms, improved safety features
+- ✅ **Runs on the latest (7.00) VESC release** — Smoother running with latest FOC algorithms, improved safety features
 
 ---
 
@@ -243,7 +250,7 @@ This package includes substantial improvements over the original [V1.50 Dive Xtr
 
 - Dive Xtras Blacktip or CudaX scooter
 - the latest 'blacktip\_dpv.vescpkg' file from [GitHub](https://github.com/mikeller/vesc_pkg/releases) or the latest official Package Store in VESC Tool
-- VESC Tool (PC) or VESC mobile app (iOS/Android), version 6.06 or higher from [VESC Project](https://vesc-project.com/vesc_tool)
+- VESC Tool (PC) or VESC mobile app (iOS/Android), version 7.00 or higher from [VESC Project](https://vesc-project.com/vesc_tool)
 - USB cable (for models without Bluetooth)
 
 ### Installation Steps
@@ -291,7 +298,7 @@ This package includes substantial improvements over the original [V1.50 Dive Xtr
 
 3. **Update the VESC firmware:**
 
-(only needed if the firmware version shown in the VESC Tool or VESC mobile app is below 6.06)
+(only needed if the firmware version shown in the VESC Tool or VESC mobile app is below 7.00)
 
 - **VESC Tool (PC):**
 
@@ -429,7 +436,7 @@ For issues, questions, or feature requests:
 ### Before Reporting Issues
 
 1. Ensure you're running the latest version
-2. Check that your VESC firmware is version 6.06 or higher
+2. Check that your VESC firmware is version 7.00 or higher
 3. Verify your settings are properly saved
 4. Try resetting to default settings to isolate the issue
 5. Enable the debug log and check it in VESC Tool (LispBM Scripting tab)

--- a/blacktip_dpv/blacktip_dpv.lisp
+++ b/blacktip_dpv/blacktip_dpv.lisp
@@ -1,6 +1,9 @@
+; For architecture notes and VESC 7.00 porting details, see DEVELOPMENT.md.
+
 ; =============================================================================
-; Constants
+; CONST BLOCK 1 - constants and the debug-logging macro (flashed, immutable)
 ; =============================================================================
+@const-start
 
 ; Sleep intervals (seconds) - controls loop frequencies
 (define SLEEP_STATE_MACHINE 0.02)     ; 50Hz - button state polling
@@ -134,85 +137,95 @@
 ; Settle time after startup before allowing more beeper indications (e.g. thirds warning)
 (define STARTUP_TUNE_SETTLE 1.0)
 
-; Display LUT binary format helpers (init-only, not moved to flash)
-(defun validate_lut_header (data magic expected_version)
-{
-    (var file_magic (bufget-u32 data 0 'little-endian))
-    (var file_version (bufget-u16 data 4 'little-endian))
-    (var num_items (bufget-u16 data 6 'little-endian))
-    (if (!= file_magic magic)
-        nil
-        (if (!= file_version expected_version)
-            nil
-            num_items
-        )
+; Lightweight macro to conditionally evaluate debug logging expressions
+; Only evaluates the logging expression when debug_enabled is 1
+; This prevents expensive str-merge and to-str calls on memory-constrained targets
+(define debug_log_format (macro (expr)
+    `(if (and (not-eq debug_enabled nil) (= debug_enabled 1))
+        (puts ,expr)
     )
-})
+))
 
-(defun load_lookup_tables ()
-{
-    ; Import display and brightness lookup tables from binary files
-    ; These files are generated at build time from CSV sources
-    (import "generated/display_lut.bin" 'display_lut_bin)
+@const-end
 
-    ; Initialize display LUT (returns number of frames or nil on error)
-    (var display_num_frames (validate_lut_header display_lut_bin 0x4C555444u32 1))
+; =============================================================================
+; MUTABLE GLOBAL STATE - heap-resident (NOT flashed), so setvar/set works.
+; Defined here (after the constants block) so initialisers may reference the
+; constants above. main re-initialises these at runtime.
+; =============================================================================
 
-    ; Verify LUTs loaded successfully - halt if validation fails
-    (if (not display_num_frames)
-        (exit-error "LUT validation failed: display"))
-})
+; --- EEPROM-backed configuration ---
+(define max_speed_no 0)
+(define start_speed 0)
+(define jump_speed 0)
+(define use_safe_start 0)
+(define enable_reverse 0)
+(define enable_smart_cruise 0)
+(define smart_cruise_timeout 0)
+(define rotation 0)
+(define disp_brightness 0)
+(define hardware_configuration 0)
+(define enable_battery_beeps 0)
+(define beeps_vol 0)
+(define cudax_flip 0)
+(define rotation2 0)
+(define enable_trigger_beeps 0)
+(define enable_smart_cruise_auto_engage 0)
+(define smart_cruise_auto_engage_time 0)
+(define enable_thirds_warning_startup 0)
+(define battery_calculation_method 0)
+(define debug_enabled 0)
+(define speed_set 0)
+(define scooter_type 0)
 
-; EEPROM initialization (init-only, not moved to flash)
-(defun eeprom_set_defaults ()
-{
-    (if (not-eq (eeprom-read-i 127) (to-i32 1)) {
-        (puts "EEPROM: Initializing defaults for 1.0.0")
-        ; Check for current version marker (blacktip_dpv release 1.0.0)
-        ; New settings added in version 1.0.0
-        (eeprom_store_i_if_changed 25 0) ; Enable Auto-Engage Smart Cruise. 1=On 0=Off
-        (eeprom_store_i_if_changed 26 10) ; Auto-Engage Time in seconds (5-30 seconds)
-        (eeprom_store_i_if_changed 27 0) ; Enable Thirds warning on from power-up. 1=On 0=Off
-        (eeprom_store_i_if_changed 28 0) ; Battery calculation method: 0=Voltage-based, 1=Ampere-hour based
-        (eeprom_store_i_if_changed 29 0) ; Enable Debug Logging. 1=On 0=Off
+; --- Runtime state machine / motor / display vars ---
+(define sw_state 0)
+(define sw_pressed 0)
+(define timer_start 0)
+(define timer_duration 0)
+(define initial_press_time 0)
+(define clicks 0)
+(define speed SPEED_OFF)
+(define new_start_speed 0)
+(define speed_set_via_jump nil)       ; Track if current speed was set via jump (triple-click) and not manually changed
+(define smart_cruise SMART_CRUISE_OFF)
 
-        (if (not-eq (eeprom-read-i 127) (to-i32 150)) {
-            (puts "EEPROM: No previous version detected, setting all defaults")
-            ; Check for previous version marker (Dive Xtras V1.50 'Poseidon')
-            ; User speeds, ie 1 thru 8 are only used in the GUI, this lisp code uses speeds 0-9 with 0 & 1 being the 2 reverse speeds.
-            ; 99 is used as the "off" speed
-            (eeprom_store_i_if_changed 0 45) ; Reverse Speed 2 %
-            (eeprom_store_i_if_changed 1 20) ; Untangle Speed 1 %
-            (eeprom_store_i_if_changed 2 30) ; Speed 1 %
-            (eeprom_store_i_if_changed 3 38) ; Speed 2 %
-            (eeprom_store_i_if_changed 4 46) ; Speed 3 %
-            (eeprom_store_i_if_changed 5 54) ; Speed 4 %
-            (eeprom_store_i_if_changed 6 62) ; Speed 5 %
-            (eeprom_store_i_if_changed 7 70) ; Speed 6 %
-            (eeprom_store_i_if_changed 8 78) ; Speed 7 %
-            (eeprom_store_i_if_changed 9 100) ; Speed 8 %
-            (eeprom_store_i_if_changed 10 9) ; Maximum number of Speeds to use, must be greater or equal to start_speed (actual speed #, not user speed)
-            (eeprom_store_i_if_changed 11 4) ; Speed the scooter starts in. Range 2-9, must be less or equal to the max_speed_no (actual speed #, not user speed)
-            (eeprom_store_i_if_changed 12 7) ; Speed to jump to on triple click, (actual speed #, not user speed)
-            (eeprom_store_i_if_changed 13 1) ; Turn safe start on or off 1=On 0=Off
-            (eeprom_store_i_if_changed 14 0) ; Enable Reverse speed. 1=On 0=Off
-            (eeprom_store_i_if_changed 15 0) ; Enable Smart Cruise (3 clicks while running). 1=On 0=Off
-            (eeprom_store_i_if_changed 16 60) ; How long before Smart Cruise times out and requires reactivation in sec.
-            (eeprom_store_i_if_changed 17 0) ; rotation of Display, 0-3 . Each number rotates display 90 deg.
-            (eeprom_store_i_if_changed 18 5) ; Display Brighness 0-5
-            (eeprom_store_i_if_changed 19 0) ; Hardware configuration, 0 = Blacktip HW60 + Ble, 1 = Blacktip HW60 - Ble, 2 = Blacktip HW410 - Ble, 3 = Cuda-X HW60 + Ble, 4 = Cuda-X HW60 - Ble
-            (eeprom_store_i_if_changed 20 0) ; Battery Beeps
-            (eeprom_store_i_if_changed 21 3) ; Beep Volume
-            (eeprom_store_i_if_changed 22 0) ; CudaX Flip Screens
-            (eeprom_store_i_if_changed 23 0) ; 2nd Screen rotation of Display, 0-3 . Each number rotates display 90 deg.
-            (eeprom_store_i_if_changed 24 0) ; Trigger Click Beeps
-        })
-        ; Mark as initialised for 1.0.0
-        (eeprom_store_i_if_changed 127 1) ; indicate that the defaults have been applied
-        (puts "EEPROM: Defaults initialized successfully")
-    })
-})
+(define state_last_state STATE_UNINITIALIZED)
+(define state_last_change_time 0)
+(define state_last_reason "")
 
+(define safe_start_timer 0)
+(define soft_start_timer 0)
+(define soft_start_active 0)
+(define safe_start_attempt_speed SPEED_OFF)
+(define safe_start_failures 0)
+(define safe_start_status 'idle)
+
+(define actual_batt 0)
+(define thirds_total 0)
+(define warning_counter 0)            ; Count how many times the 3rds warnings have been triggered.
+(define thirds_warning_latched 0)     ; Prevents repeated long-press activation
+
+(define click_beep 0)
+(define disp_timer_start 0)           ; Timer for display duration
+(define disp_num 1)                   ; variable used to define the display screen you are accesing 0-X
+(define last_disp_num 1)              ; variable used to track last display screen show
+(define batt_disp_timer_start 0)      ; Timer to see if Battery display has been triggered
+(define last_batt_disp_num 3)         ; variable used to track last display screen show
+(define startup_tune_done_time 0)     ; Timestamp when startup tune finished (0 = not done yet)
+(define batt_beeps_pending 0)         ; Battery beep count deferred until startup tune settle delay
+
+; Display LUT byte array. import MUST be a top-level form (not inside a flashed
+; const-block function), so the binding survives onto the heap. VESC Tool embeds
+; generated/display_lut.bin at upload time; flashed functions reference
+; display_lut_bin and resolve it at call time.
+(import "generated/display_lut.bin" 'display_lut_bin)
+
+; =============================================================================
+; CONST BLOCK 2 - all functions (flashed, immutable). Function order is not
+; significant for flashing because LispBM resolves symbols at call time.
+; =============================================================================
+@const-start
 
 ; Helper function to reduce EEPROM wear by only writing when value changes
 (defun eeprom_store_i_if_changed (addr new_val)
@@ -223,8 +236,13 @@
     )
 })
 
-(move-to-flash eeprom_store_i_if_changed)
-
+; Debug logging helper function
+(defun debug_log (msg)
+{
+    (if (and (not-eq debug_enabled nil) (= debug_enabled 1))
+        (puts msg)
+    )
+})
 
 ; =============================================================================
 ; Safe Start Helpers
@@ -248,15 +266,11 @@
     })
 })
 
-(move-to-flash safe_start_set_status)
-
 ; Helper to set soft_start_active (silent - no logging to reduce noise)
 (defun soft_start_set_active (val)
 {
     (setvar 'soft_start_active val)
 })
-
-(move-to-flash soft_start_set_active)
 
 (defun safe_start_reset_state ()
 {
@@ -266,8 +280,6 @@
     (safe_start_set_status 'idle)
     (soft_start_set_active 0)
 })
-
-(move-to-flash safe_start_reset_state)
 
 (defun safe_start_begin (target_speed)
 {
@@ -285,8 +297,6 @@
     })
 })
 
-(move-to-flash safe_start_begin)
-
 (defun safe_start_success ()
 {
     (setvar 'safe_start_timer 0)
@@ -294,8 +304,6 @@
     (setvar 'safe_start_failures 0)
     (safe_start_set_status 'success)
 })
-
-(move-to-flash safe_start_success)
 
 (defun safe_start_increment_failure (reason)
 {
@@ -306,14 +314,10 @@
     })
 })
 
-(move-to-flash safe_start_increment_failure)
-
 (defun safe_start_should_retry ()
 {
     (< safe_start_failures SAFE_START_MAX_RETRIES)
 })
-
-(move-to-flash safe_start_should_retry)
 
 (defun safe_start_abort_with_reason (reason)
 {
@@ -332,14 +336,10 @@
     })
 })
 
-(move-to-flash safe_start_abort_with_reason)
-
 (defun safe_start_value_valid (value max_abs)
 {
     (and (= value value) (< (abs value) max_abs))
 })
-
-(move-to-flash safe_start_value_valid)
 
 (defun safe_start_telemetry_valid (rpm duty current)
 {
@@ -348,8 +348,6 @@
          (safe_start_value_valid current 200))
 })
 
-(move-to-flash safe_start_telemetry_valid)
-
 (defun safe_start_met_success_criteria (rpm duty current)
 {
     (and (> (abs rpm) SAFE_START_MIN_RPM)
@@ -357,9 +355,8 @@
          (< (abs current) SAFE_START_MAX_CURRENT))
 })
 
-(move-to-flash safe_start_met_success_criteria)
-
-; Settings initialization (init-only, not moved to flash)
+; Settings initialization (init-only, but harmless to flash - it only reads
+; eeprom and writes mutable heap globals via setvar)
 (defun update_settings_from_eeprom ()
 {
     (setvar 'max_speed_no (eeprom-read-i 10))
@@ -403,6 +400,48 @@
     )
 })
 
+(defun log_settings_1 ()
+{
+    (debug_log_format (str-merge "- max_speed_no: " (to-str (to-i max_speed_no))
+        "\n- start_speed: " (to-str (to-i start_speed))
+        "\n- jump_speed: " (to-str (to-i jump_speed))
+        "\n- use_safe_start: " (to-str (to-i use_safe_start))
+        "\n- enable_reverse: " (to-str (to-i enable_reverse))
+        "\n- enable_smart_cruise: " (to-str (to-i enable_smart_cruise))
+        "\n- smart_cruise_timeout: " (to-str (to-i smart_cruise_timeout))
+        "\n- rotation: " (to-str (to-i rotation))
+        "\n- disp_brightness: " (to-str (to-i disp_brightness))
+        "\n- enable_battery_beeps: " (to-str (to-i enable_battery_beeps))
+        "\n- beeps_vol: " (to-str (to-i beeps_vol))
+        "\n- cudax_flip: " (to-str (to-i cudax_flip))
+        "\n- rotation2: " (to-str (to-i rotation2))
+        "\n- enable_trigger_beeps: " (to-str (to-i enable_trigger_beeps))
+    ))
+})
+
+(defun log_settings_2 ()
+{
+    (debug_log_format (str-merge "- enable_smart_cruise_auto_engage: " (to-str (to-i enable_smart_cruise_auto_engage))
+        "\n- smart_cruise_auto_engage_time: " (to-str (to-i smart_cruise_auto_engage_time))
+        "\n- enable_thirds_warning_startup: " (to-str (to-i enable_thirds_warning_startup))
+        "\n- battery_calculation_method: " (to-str (to-i battery_calculation_method))
+    ))
+})
+
+(defun log_speeds ()
+{
+    (debug_log_format (str-merge "- speed (reverse): " (to-str (to-i (ix speed_set 0)))
+        "\n- speed (untangle): " (to-str (to-i (ix speed_set 1)))
+        "\n- speed (1): " (to-str (to-i (ix speed_set 2)))
+        "\n- speed (2): " (to-str (to-i (ix speed_set 3)))
+        "\n- speed (3): " (to-str (to-i (ix speed_set 4)))
+        "\n- speed (4): " (to-str (to-i (ix speed_set 5)))
+        "\n- speed (5): " (to-str (to-i (ix speed_set 6)))
+        "\n- speed (6): " (to-str (to-i (ix speed_set 7)))
+        "\n- speed (7): " (to-str (to-i (ix speed_set 8)))
+        "\n- speed (8): " (to-str (to-i (ix speed_set 9)))
+    ))
+})
 
 (defun log_startup ()
 {
@@ -426,73 +465,6 @@
     })
 })
 
-
-(defun log_settings_1 ()
-{
-    (debug_log_format (str-merge "- max_speed_no: " (to-str (to-i max_speed_no))
-        "\n- start_speed: " (to-str (to-i start_speed))
-        "\n- jump_speed: " (to-str (to-i jump_speed))
-        "\n- use_safe_start: " (to-str (to-i use_safe_start))
-        "\n- enable_reverse: " (to-str (to-i enable_reverse))
-        "\n- enable_smart_cruise: " (to-str (to-i enable_smart_cruise))
-        "\n- smart_cruise_timeout: " (to-str (to-i smart_cruise_timeout))
-        "\n- rotation: " (to-str (to-i rotation))
-        "\n- disp_brightness: " (to-str (to-i disp_brightness))
-        "\n- enable_battery_beeps: " (to-str (to-i enable_battery_beeps))
-        "\n- beeps_vol: " (to-str (to-i beeps_vol))
-        "\n- cudax_flip: " (to-str (to-i cudax_flip))
-        "\n- rotation2: " (to-str (to-i rotation2))
-        "\n- enable_trigger_beeps: " (to-str (to-i enable_trigger_beeps))
-    ))
-})
-
-
-(defun log_settings_2 ()
-{
-    (debug_log_format (str-merge "- enable_smart_cruise_auto_engage: " (to-str (to-i enable_smart_cruise_auto_engage))
-        "\n- smart_cruise_auto_engage_time: " (to-str (to-i smart_cruise_auto_engage_time))
-        "\n- enable_thirds_warning_startup: " (to-str (to-i enable_thirds_warning_startup))
-        "\n- battery_calculation_method: " (to-str (to-i battery_calculation_method))
-    ))
-})
-
-
-(defun log_speeds ()
-{
-    (debug_log_format (str-merge "- speed (reverse): " (to-str (to-i (ix speed_set 0)))
-        "\n- speed (untangle): " (to-str (to-i (ix speed_set 1)))
-        "\n- speed (1): " (to-str (to-i (ix speed_set 2)))
-        "\n- speed (2): " (to-str (to-i (ix speed_set 3)))
-        "\n- speed (3): " (to-str (to-i (ix speed_set 4)))
-        "\n- speed (4): " (to-str (to-i (ix speed_set 5)))
-        "\n- speed (5): " (to-str (to-i (ix speed_set 6)))
-        "\n- speed (6): " (to-str (to-i (ix speed_set 7)))
-        "\n- speed (7): " (to-str (to-i (ix speed_set 8)))
-        "\n- speed (8): " (to-str (to-i (ix speed_set 9)))
-    ))
-})
-
-
-; Debug logging helper function
-(defun debug_log (msg)
-{
-    (if (and (not-eq debug_enabled nil) (= debug_enabled 1))
-        (puts msg)
-    )
-})
-
-(move-to-flash debug_log)
-
-; Lightweight macro to conditionally evaluate debug logging expressions
-; Only evaluates the logging expression when debug_enabled is 1
-; This prevents expensive str-merge and to-str calls on memory-constrained targets
-(define debug_log_format (macro (expr)
-    `(if (and (not-eq debug_enabled nil) (= debug_enabled 1))
-        (puts ,expr)
-    )
-))
-
-
 (defun calculate_corrected_battery ()
 {
     ; Calculate corrected battery percentage from raw battery reading
@@ -503,8 +475,6 @@
         (* BATTERY_COEFF_1 raw_batt)
     )
 })
-
-(move-to-flash calculate_corrected_battery)
 
 (defun calculate_ah_based_battery ()
 {
@@ -518,8 +488,6 @@
     )
 })
 
-(move-to-flash calculate_ah_based_battery)
-
 (defun get_battery_level ()
     ; Get battery level using the configured calculation method
     (if (= battery_calculation_method 1)
@@ -527,8 +495,6 @@
         (calculate_corrected_battery)
     )
 )
-
-(move-to-flash get_battery_level)
 
 (defun receive_data (data)
 {
@@ -551,9 +517,7 @@
     })
 })
 
-(move-to-flash receive_data)
-
-; Setup functions (init-only, not moved to flash)
+; Setup functions
 (defun setup_event_handler ()
 {
     (defun event_handler ()
@@ -615,14 +579,9 @@
     })
 })
 
-
 (defun state_metrics_reset ()
 {
     ; State machine tracking (minimal for memory conservation)
-    (define state_last_state STATE_UNINITIALIZED)
-    (define state_last_change_time 0)
-    (define state_last_reason "")
-
     (setvar 'state_last_state STATE_UNINITIALIZED)
     (setvar 'state_last_change_time (systime))
     (setvar 'state_last_reason "startup")
@@ -646,10 +605,6 @@
     (spawn thread_stack handler)
 })
 
-(move-to-flash state_metrics_reset)
-(move-to-flash state_record_transition)
-(move-to-flash state_transition_to)
-
 ; =============================================================================
 ; RPM Calculation Helper
 ; =============================================================================
@@ -662,8 +617,6 @@
         (t value)
     )
 })
-
-(move-to-flash clamp)
 
 (defun speed_percentage_at (speed_index)
 {
@@ -685,8 +638,6 @@
     })
 })
 
-(move-to-flash speed_percentage_at)
-
 (defun calculate_rpm (speed_index divisor)
 {
     (var speed_percent (speed_percentage_at speed_index))
@@ -701,8 +652,6 @@
         base_rpm
     )
 })
-
-(move-to-flash calculate_rpm)
 
 ; =============================================================================
 ; State Machine Design Notes:
@@ -750,8 +699,6 @@
     clamped_speed
 })
 
-(move-to-flash set_speed_safe)
-
 ; =============================================================================
 ; Smart Cruise Timeout Helper
 ; =============================================================================
@@ -774,9 +721,6 @@
         })
     )
 })
-
-(move-to-flash check_smart_cruise_timeout)
-
 
 (defun smart_cruise_leds_count ()
 {
@@ -808,9 +752,6 @@
     })
 })
 
-(move-to-flash smart_cruise_leds_count)
-
-
 (defun state_handler_off ()
 {
     ; xxxx State "0" Off
@@ -834,9 +775,6 @@
     })
 })
 
-(move-to-flash state_handler_off)
-
-
 (defun smart_cruise_upgrade_if_needed ()
 {
     (if (= smart_cruise SMART_CRUISE_HALF_ENABLED) {
@@ -846,9 +784,6 @@
         (set-rpm (calculate_rpm speed RPM_PERCENT_DENOMINATOR))
     })
 })
-
-(move-to-flash smart_cruise_upgrade_if_needed)
-
 
 ; Encapsulated click action handler
 (defun apply_click_action (click_count)
@@ -987,8 +922,6 @@
     )
 })
 
-(move-to-flash apply_click_action)
-
 ; xxxx STATE 1 Counting clicks
 (defun state_handler_counting_clicks ()
 {
@@ -1036,8 +969,6 @@
     })
 })
 
-(move-to-flash state_handler_counting_clicks)
-
 ; xxxx State 2 "Pressed"
 (defun state_handler_pressed ()
 {
@@ -1083,8 +1014,6 @@
         })
     })
 })
-
-(move-to-flash state_handler_pressed)
 
 ; xxxx State 3 "Going Off"
 (defun state_handler_going_off ()
@@ -1158,8 +1087,6 @@
         }) ; end Timer expiry
     }) ; end state
 })
-
-(move-to-flash state_handler_going_off)
 
 (defun start_motor_speed_loop ()
 {
@@ -1278,9 +1205,6 @@
     })
 })
 
-(move-to-flash start_motor_speed_loop)
-
-; Init-only function (not moved to flash)
 (defun thirds_warning_startup ()
 {
     (if (> enable_thirds_warning_startup 0) {
@@ -1294,7 +1218,6 @@
         (setvar 'warning_counter 0)
     })
 })
-
 
 (defun apply_smart_cruise_timer_bar (pixbuf)
 {
@@ -1321,9 +1244,6 @@
 
     leds_lit ; Return the LED count or -1
 })
-
-(move-to-flash apply_smart_cruise_timer_bar)
-
 
 (defun start_display_output_loop ()
 {
@@ -1412,15 +1332,11 @@
     })
 })
 
-(move-to-flash start_display_output_loop)
-
 ; Returns true once the startup tune has finished AND 1 second has elapsed,
 ; giving a clear gap between the tune and the battery status beeps.
 (defun tune-settled ()
     (and (> startup_tune_done_time 0) (> (secs-since startup_tune_done_time) STARTUP_TUNE_SETTLE))
 )
-
-(move-to-flash tune-settled)
 
 ; **** Program that triggers the display to show battery status ****
 (defun start_display_battery_loop ()
@@ -1523,16 +1439,12 @@
     })
 })
 
-(move-to-flash start_display_battery_loop)
-
 (defun beeper (beeps)
 (loopwhile (and (= enable_battery_beeps 1) (> batt_disp_timer_start 0) (> beeps 0)) {
        (sleep SLEEP_UI_UPDATE)
        (foc-beep 350 0.5 beeps_vol)
       (setvar 'beeps (- beeps 1))
     }))
-
-(move-to-flash beeper)
 
 ; xxxx warbler Program xxxx"
 (defun warbler (Tone Time Delay)
@@ -1543,8 +1455,6 @@
     (foc-beep Tone Time beeps_vol)
     (foc-beep (- Tone 200) Time beeps_vol)
 })
-
-(move-to-flash warbler)
 
 ; ***** Imperial March Theme *****
 ; Plays the first ~9 bars of the Imperial March on startup
@@ -1566,7 +1476,7 @@
         (sleep 0.14)
         (foc-beep 392 0.35 beeps_vol)  ; G quarter
         (sleep 0.37)
-        
+
         ; Bar 3-4: Eb-Bb G (hold)
         (foc-beep 311 0.25 beeps_vol) ; Eb short
         (sleep 0.27)
@@ -1574,7 +1484,7 @@
         (sleep 0.14)
         (foc-beep 392 0.7 beeps_vol)  ; G half note
         (sleep 0.74)
-        
+
         ; Bar 5-6: D D D Eb-Bb Gb
         (foc-beep 587 0.35 beeps_vol)  ; D quarter
         (sleep 0.37)
@@ -1588,7 +1498,7 @@
         (sleep 0.14)
         (foc-beep 370 0.35 beeps_vol)  ; Gb quarter
         (sleep 0.37)
-        
+
         ; Bar 7-8: Eb-Bb G (hold)
         (foc-beep 311 0.25 beeps_vol) ; Eb short
         (sleep 0.27)
@@ -1599,8 +1509,6 @@
     })
     (setvar 'startup_tune_done_time (systime)) ; Record when startup tune finished
 })
-
-(move-to-flash play_imperial_march)
 
 ; ***** Program that beeps trigger clicks
 (defun start_beeper_loop ()
@@ -1634,9 +1542,8 @@
     })
 })
 
-(move-to-flash start_beeper_loop)
-
-; Init-only function (not moved to flash)
+; Init-only peripheral setup. Lives in the init/main call path because
+; image-save does not restore external hardware state.
 (defun peripherals_setup ()
 {
     (if (or (= 0 hardware_configuration) (= 3 hardware_configuration)) ; turn on i2c for the screen based on wiring. 0 = Blacktip with Bluetooth, 3 = CudaX with Bluetooth
@@ -1647,13 +1554,110 @@
                     (i2c-start 'rate-400k 'pin-tx 'pin-rx) ; tested on HW 410 Tested: SN 189, SN 1691
                     (nil))))
 
-    (i2c-tx-rx 0x70 (list 0x21)) ; start the oscillator
+    ; HT16K33 init sequence: oscillator -> display ON -> brightness.
+    ;
+    ; VESC 7.00 BUG WORKAROUND - swallowed first I2C message:
+    ; On 7.00 the FIRST i2c-tx-rx issued after i2c-start (i.e. the first
+    ; transaction on a freshly muxed bus - which happens on every COLD boot, and
+    ; whenever the I2C pins are (re)configured) is silently swallowed: it never
+    ; reaches the device. On 6.06 that same single 0x21 was delivered and the
+    ; panel lit. The result on 7.00 is that the oscillator-enable is lost, the
+    ; HT16K33 oscillator never starts, and the panel stays dark on a cold boot.
+    ; A warm :reset masked the bug two ways: the chip (and its oscillator) stayed
+    ; powered from the previous session, and the bus was already muxed so no
+    ; transaction was swallowed.
+    ;
+    ; Workaround: send the oscillator-enable (0x21) TWICE. The first write is the
+    ; sacrificial one that the bug swallows; the second one actually reaches the
+    ; controller and starts the oscillator. No delay between them is needed.
+    (i2c-tx-rx 0x70 (list 0x21)) ; sacrificial: absorbs the swallowed first transaction
+    (i2c-tx-rx 0x70 (list 0x21)) ; real oscillator / system-setup enable
     ; Set brightness using BRIGHTNESS_LUT (six discrete levels, indices 0..5)
     (i2c-tx-rx 0x70 (list (ix BRIGHTNESS_LUT (clamp disp_brightness 0 (- (length BRIGHTNESS_LUT) 1))))) ; set brightness safely
 
     (if (= scooter_type 1) { ; For cuda X setup second screen
+            ; The bus is already muxed and exercised by the 0x70 writes above, so
+            ; the swallow-the-first-message bug does not apply here - a single
+            ; 0x21 is sufficient for the second controller.
             (i2c-tx-rx 0x71 (list 0x21)) ; start the oscillator
             (i2c-tx-rx 0x71 (list (ix BRIGHTNESS_LUT (clamp disp_brightness 0 (- (length BRIGHTNESS_LUT) 1))))) ; set brightness safely
+    })
+})
+
+; Display LUT binary format helpers (init-only)
+(defun validate_lut_header (data magic expected_version)
+{
+    (var file_magic (bufget-u32 data 0 'little-endian))
+    (var file_version (bufget-u16 data 4 'little-endian))
+    (var num_items (bufget-u16 data 6 'little-endian))
+    (if (!= file_magic magic)
+        nil
+        (if (!= file_version expected_version)
+            nil
+            num_items
+        )
+    )
+})
+
+(defun load_lookup_tables ()
+{
+    ; display_lut_bin is imported at top level (between the const blocks); here
+    ; we only validate the already-loaded byte array.
+    ; Initialize display LUT (returns number of frames or nil on error)
+    (var display_num_frames (validate_lut_header display_lut_bin 0x4C555444u32 1))
+
+    ; Verify LUTs loaded successfully - halt if validation fails
+    (if (not display_num_frames)
+        (exit-error "LUT validation failed: display"))
+})
+
+; EEPROM initialization (init-only)
+(defun eeprom_set_defaults ()
+{
+    (if (not-eq (eeprom-read-i 127) (to-i32 1)) {
+        (puts "EEPROM: Initializing defaults for 1.0.0")
+        ; Check for current version marker (blacktip_dpv release 1.0.0)
+        ; New settings added in version 1.0.0
+        (eeprom_store_i_if_changed 25 0) ; Enable Auto-Engage Smart Cruise. 1=On 0=Off
+        (eeprom_store_i_if_changed 26 10) ; Auto-Engage Time in seconds (5-30 seconds)
+        (eeprom_store_i_if_changed 27 0) ; Enable Thirds warning on from power-up. 1=On 0=Off
+        (eeprom_store_i_if_changed 28 0) ; Battery calculation method: 0=Voltage-based, 1=Ampere-hour based
+        (eeprom_store_i_if_changed 29 0) ; Enable Debug Logging. 1=On 0=Off
+
+        (if (not-eq (eeprom-read-i 127) (to-i32 150)) {
+            (puts "EEPROM: No previous version detected, setting all defaults")
+            ; Check for previous version marker (Dive Xtras V1.50 'Poseidon')
+            ; User speeds, ie 1 thru 8 are only used in the GUI, this lisp code uses speeds 0-9 with 0 & 1 being the 2 reverse speeds.
+            ; 99 is used as the "off" speed
+            (eeprom_store_i_if_changed 0 45) ; Reverse Speed 2 %
+            (eeprom_store_i_if_changed 1 20) ; Untangle Speed 1 %
+            (eeprom_store_i_if_changed 2 30) ; Speed 1 %
+            (eeprom_store_i_if_changed 3 38) ; Speed 2 %
+            (eeprom_store_i_if_changed 4 46) ; Speed 3 %
+            (eeprom_store_i_if_changed 5 54) ; Speed 4 %
+            (eeprom_store_i_if_changed 6 62) ; Speed 5 %
+            (eeprom_store_i_if_changed 7 70) ; Speed 6 %
+            (eeprom_store_i_if_changed 8 78) ; Speed 7 %
+            (eeprom_store_i_if_changed 9 100) ; Speed 8 %
+            (eeprom_store_i_if_changed 10 9) ; Maximum number of Speeds to use, must be greater or equal to start_speed (actual speed #, not user speed)
+            (eeprom_store_i_if_changed 11 4) ; Speed the scooter starts in. Range 2-9, must be less or equal to the max_speed_no (actual speed #, not user speed)
+            (eeprom_store_i_if_changed 12 7) ; Speed to jump to on triple click, (actual speed #, not user speed)
+            (eeprom_store_i_if_changed 13 1) ; Turn safe start on or off 1=On 0=Off
+            (eeprom_store_i_if_changed 14 0) ; Enable Reverse speed. 1=On 0=Off
+            (eeprom_store_i_if_changed 15 0) ; Enable Smart Cruise (3 clicks while running). 1=On 0=Off
+            (eeprom_store_i_if_changed 16 60) ; How long before Smart Cruise times out and requires reactivation in sec.
+            (eeprom_store_i_if_changed 17 0) ; rotation of Display, 0-3 . Each number rotates display 90 deg.
+            (eeprom_store_i_if_changed 18 5) ; Display Brighness 0-5
+            (eeprom_store_i_if_changed 19 0) ; Hardware configuration, 0 = Blacktip HW60 + Ble, 1 = Blacktip HW60 - Ble, 2 = Blacktip HW410 - Ble, 3 = Cuda-X HW60 + Ble, 4 = Cuda-X HW60 - Ble
+            (eeprom_store_i_if_changed 20 0) ; Battery Beeps
+            (eeprom_store_i_if_changed 21 3) ; Beep Volume
+            (eeprom_store_i_if_changed 22 0) ; CudaX Flip Screens
+            (eeprom_store_i_if_changed 23 0) ; 2nd Screen rotation of Display, 0-3 . Each number rotates display 90 deg.
+            (eeprom_store_i_if_changed 24 0) ; Trigger Click Beeps
+        })
+        ; Mark as initialised for 1.0.0
+        (eeprom_store_i_if_changed 127 1) ; indicate that the defaults have been applied
+        (puts "EEPROM: Defaults initialized successfully")
     })
 })
 
@@ -1674,73 +1678,74 @@
 
     (log_startup)
 
-    (define thirds_total 0)
-    (define warning_counter 0) ; Count how many times the 3rds warnings have been triggered.
-    (define thirds_warning_latched 0) ; Prevents repeated long-press activation
+    ; State 3rds tracking - re-initialised at runtime (heap globals)
+    (setvar 'thirds_total 0)
+    (setvar 'warning_counter 0) ; Count how many times the 3rds warnings have been triggered.
+    (setvar 'thirds_warning_latched 0) ; Prevents repeated long-press activation
 
     (thirds_warning_startup)
 
     (setup_event_handler)
 
-    (define sw_state 0)
-    (define timer_start 0)
-    (define timer_duration 0)
-    (define initial_press_time 0)
-    (define clicks 0)
-    (define actual_batt 0)
-    (define new_start_speed start_speed)
-    (define speed_set_via_jump nil) ; Track if current speed was set via jump (triple-click) and not manually changed
-    (define state_last_state STATE_UNINITIALIZED)
-    (define state_last_change_time 0)
-    (define state_last_reason "")
+    (setvar 'sw_state 0)
+    (setvar 'timer_start 0)
+    (setvar 'timer_duration 0)
+    (setvar 'initial_press_time 0)
+    (setvar 'clicks 0)
+    (setvar 'actual_batt 0)
+    (setvar 'new_start_speed start_speed)
+    (setvar 'speed_set_via_jump nil) ; Track if current speed was set via jump (triple-click) and not manually changed
+    (setvar 'state_last_state STATE_UNINITIALIZED)
+    (setvar 'state_last_change_time 0)
+    (setvar 'state_last_reason "")
 
     (state_metrics_reset)
 
-    (define speed SPEED_OFF)
-    (define safe_start_timer 0)
-    (define soft_start_timer 0)
-    (define soft_start_active 0)
-    (define safe_start_attempt_speed SPEED_OFF)
-    (define safe_start_failures 0)
-    (define safe_start_status 'idle)
+    (setvar 'speed SPEED_OFF)
+    (setvar 'safe_start_timer 0)
+    (setvar 'soft_start_timer 0)
+    (setvar 'soft_start_active 0)
+    (setvar 'safe_start_attempt_speed SPEED_OFF)
+    (setvar 'safe_start_failures 0)
+    (setvar 'safe_start_status 'idle)
 
     (start_motor_speed_loop)
 
-    (define click_beep 0)
+    (setvar 'click_beep 0)
 
     (start_beeper_loop)
 
-    (define disp_timer_start 0) ; Timer for display duration
+    (setvar 'disp_timer_start 0) ; Timer for display duration
 
     (peripherals_setup)
 
-    (define disp_num 1) ; variable used to define the display screen you are accesing 0-X
-    (define last_disp_num 1) ; variable used to track last display screen show
+    (setvar 'disp_num 1) ; variable used to define the display screen you are accesing 0-X
+    (setvar 'last_disp_num 1) ; variable used to track last display screen show
 
     (start_display_output_loop)
 
-    (define batt_disp_timer_start 0) ; Timer to see if Battery display has been triggered
-    (define last_batt_disp_num 3) ; variable used to track last display screen show
-    (define startup_tune_done_time 0) ; Timestamp when startup tune finished (0 = not done yet)
-    (define batt_beeps_pending 0)    ; Battery beep count deferred until startup tune settle delay
+    (setvar 'batt_disp_timer_start 0) ; Timer to see if Battery display has been triggered
+    (setvar 'last_batt_disp_num 3) ; variable used to track last display screen show
+    (setvar 'startup_tune_done_time 0) ; Timestamp when startup tune finished (0 = not done yet)
+    (setvar 'batt_beeps_pending 0)    ; Battery beep count deferred until startup tune settle delay
 
     (start_display_battery_loop)
 
-    (define smart_cruise SMART_CRUISE_OFF)
+    (setvar 'smart_cruise SMART_CRUISE_OFF)
 
     (start_smart_cruise_loop)
 
-    (define sw_pressed 0)
+    (setvar 'sw_pressed 0)
 
     (start_trigger_loop)
 
     (state_transition_to STATE_OFF "startup" THREAD_STACK_STATE_TRANSITIONS state_handler_off) ; ***Start state machine running for first time
 
     (setvar 'disp_num 15) ; display startup screen, change bytes if you want a different one
-    
+
     ; Play Imperial March on startup in background thread to avoid blocking
     (spawn THREAD_STACK_CLICK_BEEP play_imperial_march)
-    
+
     ; Check battery level and only play battery indication if not full (3 bars)
     ; Battery is considered "full" at > 0.75 (matching the 3-bar threshold)
     ; Allow 6+ seconds for battery to stabilize and Imperial March to finish before beeps
@@ -1750,34 +1755,25 @@
     )
 
     (puts "Startup complete")
+
+    ; Keep main resident as a persistent supervisory context instead of
+    ; returning. The worker threads (motor/display/state-machine/etc.) were all
+    ; spawned above and run independently; this loop simply keeps the main
+    ; context alive (matching the common image-save 'looping main' idiom) and
+    ; gives a single place for periodic health checks. Low frequency to keep
+    ; CPU/wakeups negligible.
+    (loopwhile t {
+        (sleep 1.0)
+        ; (optional) supervisory hooks could go here later, e.g. re-assert the
+        ; display controller or restart a thread that has died.
+    })
 })
 
-; Configuration settings
-(define max_speed_no 0)
-(define start_speed 0)
-(define jump_speed 0)
-(define use_safe_start 0)
-(define enable_reverse 0)
-(define enable_smart_cruise 0)
-(define smart_cruise_timeout 0)
-(define rotation 0)
-(define disp_brightness 0)
-(define hardware_configuration 0)
-(define enable_battery_beeps 0)
-(define beeps_vol 0)
-(define cudax_flip 0)
-(define rotation2 0)
-(define enable_trigger_beeps 0)
-(define enable_smart_cruise_auto_engage 0)
-(define smart_cruise_auto_engage_time 0)
-(define enable_thirds_warning_startup 0)
-(define battery_calculation_method 0)
-(define debug_enabled 0)
-(define speed_set 0)
-(define scooter_type 0)
+@const-end
 
+; See DEVELOPMENT.md for boot sequence details.
 (init)
 
-(image-save)
-
-(main)
+(progn
+    (image-save)
+    (main))

--- a/blacktip_dpv/tests/run_tests.py
+++ b/blacktip_dpv/tests/run_tests.py
@@ -4,6 +4,7 @@ BlackTip DPV Smoke Tests
 Tests pure functions to catch regressions before flashing hardware
 """
 
+import struct
 import sys
 
 # Test counters
@@ -176,6 +177,387 @@ def test_calculate_rpm():
     assert_near(calculate_rpm(5, 1), 25000, 0.1, "calculate_rpm: speed 5 (at threshold, forward)")
 
 # =============================================================================
+# New functions added in PR (VESC 7.00 compatibility)
+# =============================================================================
+
+# BRIGHTNESS_LUT: six discrete brightness levels sent to the HT16K33 via I2C.
+# Indices 0..5 map to hardware register values.
+BRIGHTNESS_LUT = [224, 227, 230, 233, 236, 239]
+
+# LUT binary magic for the display lookup table ('LUTD' as a little-endian u32)
+DISPLAY_LUT_MAGIC = 0x4C555444
+
+
+def validate_lut_header(data, magic, expected_version):
+    """
+    Mirror of validate_lut_header from blacktip_dpv.lisp.
+
+    Binary layout (little-endian):
+      offset 0 : u32  magic
+      offset 4 : u16  version
+      offset 6 : u16  num_items
+
+    Returns num_items on success, None on any mismatch (mirrors LispBM nil).
+    Raises struct.error if data is too short.
+    """
+    file_magic = struct.unpack_from('<I', data, 0)[0]
+    file_version = struct.unpack_from('<H', data, 4)[0]
+    num_items = struct.unpack_from('<H', data, 6)[0]
+    if file_magic != magic:
+        return None
+    if file_version != expected_version:
+        return None
+    return num_items
+
+
+def _make_lut_header(magic, version, num_items):
+    """Build an 8-byte LUT header for use in tests."""
+    return struct.pack('<IHH', magic, version, num_items)
+
+
+def debug_log(debug_enabled, msg, log_target):
+    """
+    Mirror of debug_log from blacktip_dpv.lisp (const block 2).
+
+    Only appends msg to log_target when debug_enabled is exactly 1 and not None.
+    """
+    if debug_enabled is not None and debug_enabled == 1:
+        log_target.append(msg)
+
+
+def debug_log_format(debug_enabled, expr_fn, log_target):
+    """
+    Mirror of the debug_log_format macro from blacktip_dpv.lisp (const block 1).
+
+    expr_fn is a callable that produces the string to log; it is only called
+    (lazy evaluation) when debug_enabled is 1. This models the macro behaviour
+    that prevents expensive str-merge / to-str calls in hot paths when debug is off.
+    """
+    if debug_enabled is not None and debug_enabled == 1:
+        log_target.append(expr_fn())
+
+
+def brightness_index_for(disp_brightness):
+    """
+    Mirror of the brightness clamp used in peripherals_setup.
+
+    Returns the index into BRIGHTNESS_LUT after clamping disp_brightness to
+    the valid range [0, len(BRIGHTNESS_LUT) - 1].
+    """
+    return clamp(disp_brightness, 0, len(BRIGHTNESS_LUT) - 1)
+
+
+def brightness_value_for(disp_brightness):
+    """Return the HT16K33 register value for the given brightness setting."""
+    return BRIGHTNESS_LUT[brightness_index_for(disp_brightness)]
+
+
+def simulate_i2c_init_sequence(disp_brightness, scooter_type):
+    """
+    Simulate the I2C command sequence emitted by peripherals_setup.
+
+    Returns the ordered list of (addr, data) tuples that would be sent via
+    i2c-tx-rx, modelling the VESC 7.00 double-write workaround for address 0x70.
+    scooter_type: 0 = Blacktip, 1 = CudaX.
+    """
+    commands = []
+    # VESC 7.00 workaround: two oscillator-enable writes to 0x70.
+    # First is sacrificial (absorbed by firmware bug); second reaches HT16K33.
+    commands.append((0x70, [0x21]))  # sacrificial
+    commands.append((0x70, [0x21]))  # real oscillator-enable
+    brightness_val = brightness_value_for(disp_brightness)
+    commands.append((0x70, [brightness_val]))
+    if scooter_type == 1:
+        # Second controller: bus already exercised, single write is enough.
+        commands.append((0x71, [0x21]))
+        commands.append((0x71, [brightness_val]))
+    return commands
+
+
+def state_metrics_reset_simulate(state_store):
+    """
+    Mirror of state_metrics_reset from blacktip_dpv.lisp.
+
+    In the PR the function was updated to use setvar instead of re-define,
+    meaning it only mutates already-existing heap bindings. We model this with
+    a dict that must already contain the keys (pre-declared as mutable globals).
+    """
+    STATE_UNINITIALIZED = -1
+    state_store['state_last_state'] = STATE_UNINITIALIZED
+    # state_last_change_time would be set to (systime); use a sentinel here.
+    state_store['state_last_change_time'] = 'NOW'
+    state_store['state_last_reason'] = 'startup'
+
+
+# =============================================================================
+# Test Suites — VESC 7.00 compatibility (PR changes)
+# =============================================================================
+
+def test_validate_lut_header():
+    """Test validate_lut_header — new/moved function in VESC 7.00 PR."""
+    print("\n=== Testing validate_lut_header ===")
+
+    MAGIC = DISPLAY_LUT_MAGIC
+    VERSION = 1
+
+    # Valid header: correct magic, version, and a nonzero num_items
+    data = _make_lut_header(MAGIC, VERSION, 42)
+    assert_eq(validate_lut_header(data, MAGIC, VERSION), 42,
+              "validate_lut_header: valid header returns num_items")
+
+    # Valid header with num_items == 1 (minimum realistic value)
+    data = _make_lut_header(MAGIC, VERSION, 1)
+    assert_eq(validate_lut_header(data, MAGIC, VERSION), 1,
+              "validate_lut_header: num_items = 1 returns 1")
+
+    # Valid header with num_items == 0 (edge case: returns 0, which is falsy —
+    # matches LispBM where (not 0) is true, causing exit-error in load_lookup_tables)
+    data = _make_lut_header(MAGIC, VERSION, 0)
+    assert_eq(validate_lut_header(data, MAGIC, VERSION), 0,
+              "validate_lut_header: num_items = 0 returns 0 (falsy, triggers error path)")
+
+    # Wrong magic → None
+    data = _make_lut_header(0xDEADBEEF, VERSION, 10)
+    assert_eq(validate_lut_header(data, MAGIC, VERSION), None,
+              "validate_lut_header: wrong magic returns None")
+
+    # Wrong version → None
+    data = _make_lut_header(MAGIC, 2, 10)
+    assert_eq(validate_lut_header(data, MAGIC, VERSION), None,
+              "validate_lut_header: wrong version returns None")
+
+    # Both magic and version wrong → None (magic checked first)
+    data = _make_lut_header(0xDEADBEEF, 99, 10)
+    assert_eq(validate_lut_header(data, MAGIC, VERSION), None,
+              "validate_lut_header: wrong magic and version returns None")
+
+    # Large num_items (max u16 = 65535)
+    data = _make_lut_header(MAGIC, VERSION, 65535)
+    assert_eq(validate_lut_header(data, MAGIC, VERSION), 65535,
+              "validate_lut_header: max u16 num_items")
+
+    # Regression: magic bytes in big-endian order must NOT match the little-endian magic
+    be_magic = int.from_bytes(MAGIC.to_bytes(4, 'little'), 'big')
+    data = _make_lut_header(be_magic, VERSION, 10)
+    assert_eq(validate_lut_header(data, MAGIC, VERSION), None,
+              "validate_lut_header: big-endian magic does not match little-endian parse")
+
+
+def test_debug_log():
+    """Test debug_log conditional behaviour (moved to const block 2 in PR)."""
+    print("\n=== Testing debug_log ===")
+
+    log = []
+
+    # debug_enabled == 1: message is logged
+    debug_log(1, "test message", log)
+    assert_eq(log, ["test message"],
+              "debug_log: logs when debug_enabled=1")
+
+    # debug_enabled == 0: message is NOT logged
+    log.clear()
+    debug_log(0, "should not appear", log)
+    assert_eq(log, [],
+              "debug_log: silent when debug_enabled=0")
+
+    # debug_enabled == None (LispBM nil): message is NOT logged
+    log.clear()
+    debug_log(None, "should not appear", log)
+    assert_eq(log, [],
+              "debug_log: silent when debug_enabled=None (nil)")
+
+    # debug_enabled == 2: NOT equal to 1, message is NOT logged
+    log.clear()
+    debug_log(2, "should not appear", log)
+    assert_eq(log, [],
+              "debug_log: silent when debug_enabled=2 (not exactly 1)")
+
+    # Multiple messages accumulate when enabled
+    log.clear()
+    debug_log(1, "first", log)
+    debug_log(1, "second", log)
+    assert_eq(log, ["first", "second"],
+              "debug_log: multiple messages accumulate")
+
+
+def test_debug_log_format():
+    """
+    Test debug_log_format lazy-evaluation behaviour (defined in const block 1).
+
+    The macro must NOT evaluate its expression argument when debug is disabled —
+    this is the key property that prevents expensive str-merge / to-str calls in
+    hot paths (set_speed_safe, motor control loop, etc.).
+    """
+    print("\n=== Testing debug_log_format ===")
+
+    log = []
+    eval_count = [0]  # mutable counter to detect unwanted evaluation
+
+    def expensive_expr():
+        eval_count[0] += 1
+        return "expensive string"
+
+    # debug_enabled == 1: expression IS evaluated and logged
+    debug_log_format(1, expensive_expr, log)
+    assert_eq(log, ["expensive string"],
+              "debug_log_format: evaluates and logs when debug_enabled=1")
+    assert_eq(eval_count[0], 1,
+              "debug_log_format: expression evaluated exactly once when enabled")
+
+    # debug_enabled == 0: expression is NOT evaluated (lazy)
+    log.clear()
+    eval_count[0] = 0
+    debug_log_format(0, expensive_expr, log)
+    assert_eq(log, [],
+              "debug_log_format: no output when debug_enabled=0")
+    assert_eq(eval_count[0], 0,
+              "debug_log_format: expression NOT evaluated when debug_enabled=0 (lazy)")
+
+    # debug_enabled == None: expression is NOT evaluated (lazy)
+    log.clear()
+    eval_count[0] = 0
+    debug_log_format(None, expensive_expr, log)
+    assert_eq(log, [],
+              "debug_log_format: no output when debug_enabled=None")
+    assert_eq(eval_count[0], 0,
+              "debug_log_format: expression NOT evaluated when debug_enabled=None (lazy)")
+
+
+def test_brightness_clamp():
+    """
+    Test brightness index clamping used in peripherals_setup (VESC 7.00 PR).
+
+    peripherals_setup now uses: (clamp disp_brightness 0 (- (length BRIGHTNESS_LUT) 1))
+    which maps any out-of-range setting to the nearest valid BRIGHTNESS_LUT index.
+    """
+    print("\n=== Testing brightness_clamp for peripherals_setup ===")
+
+    # Valid range: 0..5 passes through unchanged
+    assert_eq(brightness_index_for(0), 0,
+              "brightness_clamp: 0 -> index 0 (min)")
+    assert_eq(brightness_index_for(3), 3,
+              "brightness_clamp: 3 -> index 3 (mid)")
+    assert_eq(brightness_index_for(5), 5,
+              "brightness_clamp: 5 -> index 5 (max)")
+
+    # Below minimum: clamped to 0
+    assert_eq(brightness_index_for(-1), 0,
+              "brightness_clamp: -1 clamped to 0")
+    assert_eq(brightness_index_for(-100), 0,
+              "brightness_clamp: -100 clamped to 0")
+
+    # Above maximum: clamped to 5
+    assert_eq(brightness_index_for(6), 5,
+              "brightness_clamp: 6 clamped to 5")
+    assert_eq(brightness_index_for(100), 5,
+              "brightness_clamp: 100 clamped to 5")
+
+    # Verify the BRIGHTNESS_LUT register values are within the expected HT16K33 range
+    for idx in range(len(BRIGHTNESS_LUT)):
+        val = BRIGHTNESS_LUT[idx]
+        assert_eq(val >= 224 and val <= 239, True,
+                  f"brightness_clamp: BRIGHTNESS_LUT[{idx}]={val} in HT16K33 dimming range 224-239")
+
+    # brightness_value_for should map correctly to BRIGHTNESS_LUT entries
+    assert_eq(brightness_value_for(0), 224,
+              "brightness_value_for: level 0 -> 224 (dimmest)")
+    assert_eq(brightness_value_for(5), 239,
+              "brightness_value_for: level 5 -> 239 (brightest)")
+
+
+def test_i2c_init_sequence():
+    """
+    Test the I2C initialisation sequence emitted by peripherals_setup.
+
+    VESC 7.00 introduced a bug where the first i2c-tx-rx after i2c-start is
+    silently dropped. The fix is to send the HT16K33 oscillator-enable command
+    (0x21) twice: the first write is sacrificial, the second reaches the chip.
+    """
+    print("\n=== Testing I2C init sequence (VESC 7.00 double-write workaround) ===")
+
+    # Blacktip (scooter_type=0): only one display controller at address 0x70
+    cmds = simulate_i2c_init_sequence(disp_brightness=3, scooter_type=0)
+
+    assert_eq(len(cmds), 3,
+              "i2c_init: Blacktip sends exactly 3 i2c commands")
+
+    assert_eq(cmds[0], (0x70, [0x21]),
+              "i2c_init: first command is sacrificial 0x21 to 0x70")
+    assert_eq(cmds[1], (0x70, [0x21]),
+              "i2c_init: second command is real oscillator-enable 0x21 to 0x70")
+    assert_eq(cmds[0], cmds[1],
+              "i2c_init: both initial 0x21 writes are identical (workaround)")
+    assert_eq(cmds[2][0], 0x70,
+              "i2c_init: brightness command targets address 0x70")
+
+    # CudaX (scooter_type=1): second controller at 0x71, single 0x21 sufficient
+    cmds_cuda = simulate_i2c_init_sequence(disp_brightness=3, scooter_type=1)
+    assert_eq(len(cmds_cuda), 5,
+              "i2c_init: CudaX sends exactly 5 i2c commands")
+    assert_eq(cmds_cuda[3], (0x71, [0x21]),
+              "i2c_init: CudaX second screen gets single 0x21 (bus already exercised)")
+    assert_eq(cmds_cuda[4][0], 0x71,
+              "i2c_init: CudaX brightness command targets address 0x71")
+
+    # 0x70 address must NOT appear after the first 3 commands in CudaX mode
+    addresses_after_3 = [addr for addr, _ in cmds_cuda[3:]]
+    assert_eq(0x70 in addresses_after_3, False,
+              "i2c_init: no further writes to 0x70 after the first controller init")
+
+    # Regression: confirm that the old single-write approach would miss the oscillator.
+    # A single 0x21 at index 0 would be the only oscillator command — 0x70 would get
+    # brightness but never receive a working oscillator-enable on VESC 7.00.
+    single_write_0x21_count = sum(1 for addr, data in cmds if addr == 0x70 and data == [0x21])
+    assert_eq(single_write_0x21_count, 2,
+              "i2c_init: exactly 2 oscillator-enable commands sent to 0x70 (not 1)")
+
+
+def test_state_metrics_reset():
+    """
+    Test the state_metrics_reset behaviour after the setvar refactor.
+
+    In the PR, the function changed from using `define` (which re-creates bindings)
+    to `setvar` (which mutates pre-existing heap globals). The Python simulation
+    requires the keys to already exist in the state store, mirroring the new
+    requirement that mutable globals be pre-declared between the const blocks.
+    """
+    print("\n=== Testing state_metrics_reset (setvar refactor) ===")
+
+    STATE_UNINITIALIZED = -1
+
+    # Pre-declare all three mutable heap globals (as required by VESC 7.00 layout)
+    state_store = {
+        'state_last_state': 99,      # some previous state
+        'state_last_change_time': 0,
+        'state_last_reason': 'old_reason',
+    }
+
+    state_metrics_reset_simulate(state_store)
+
+    assert_eq(state_store['state_last_state'], STATE_UNINITIALIZED,
+              "state_metrics_reset: state_last_state reset to STATE_UNINITIALIZED (-1)")
+    assert_eq(state_store['state_last_change_time'], 'NOW',
+              "state_metrics_reset: state_last_change_time updated (systime sentinel)")
+    assert_eq(state_store['state_last_reason'], 'startup',
+              "state_metrics_reset: state_last_reason set to 'startup'")
+
+    # All three keys must already exist (pre-declared globals) — setvar does not create new bindings
+    assert_eq('state_last_state' in state_store, True,
+              "state_metrics_reset: state_last_state key pre-exists (setvar pattern)")
+    assert_eq('state_last_change_time' in state_store, True,
+              "state_metrics_reset: state_last_change_time key pre-exists (setvar pattern)")
+    assert_eq('state_last_reason' in state_store, True,
+              "state_metrics_reset: state_last_reason key pre-exists (setvar pattern)")
+
+    # Calling reset twice leaves deterministic values (idempotent aside from systime)
+    state_metrics_reset_simulate(state_store)
+    assert_eq(state_store['state_last_state'], STATE_UNINITIALIZED,
+              "state_metrics_reset: idempotent — second call still gives UNINITIALIZED")
+    assert_eq(state_store['state_last_reason'], 'startup',
+              "state_metrics_reset: idempotent — second call still gives 'startup'")
+
+
+# =============================================================================
 # Test Runner
 # =============================================================================
 
@@ -190,10 +572,17 @@ def run_all_tests():
     test_state_name_for()
     test_speed_percentage_at()
     test_calculate_rpm()
+    test_validate_lut_header()
+    test_debug_log()
+    test_debug_log_format()
+    test_brightness_clamp()
+    test_i2c_init_sequence()
+    test_state_metrics_reset()
 
-    print("\n╔══════════════════════════════════════════╗")
-    print(f"║  Results: {test_passes} passed, {test_failures} failed")
-    print("╚══════════════════════════════════════════╝\n")
+    print("\n══════════════════════════════════════════")
+    print(f"  Results: {test_passes} passed, {test_failures} failed")
+    print("══════════════════════════════════════════\n")
+
 
     if test_failures > 0:
         print("FAILED: Some tests did not pass")


### PR DESCRIPTION
Compatibility fix release for VESC firmware 7.00.

## Changes

### Fix: Cold-boot dark display (I2C first-message bug)

On VESC firmware 7.00, the first `i2c-tx-rx` call after `i2c-start` on a cold boot is silently dropped and never reaches the I2C device. The HT16K33 display controller's oscillator-enable command (`0x21`) was never delivered, leaving the oscillator stopped and the display permanently dark.

**Workaround:** send the oscillator-enable command twice in `peripherals_setup`; the first write is sacrificial (absorbed by the bug), the second reaches the controller.

### Fix: Package crash on second and subsequent boots (`move-to-flash` → `@const-start`)

VESC 7.00 re-evaluates package source on every boot but preserves the flash heap from the previous session. The previous `move-to-flash` calls conflicted with the already-populated flash heap and caused an abort before any threads were spawned.

**Fix:** replaced all `move-to-flash` calls with the `@const-start` / `@const-end` block syntax, which is the correct mechanism for VESC 7.00.

### Docs

- README.md: version bump to 1.3.1, added "What's New in 1.3.1" section, updated firmware requirement to 7.00.
- DEVELOPMENT.md: new "VESC 7.00 Compatibility" section documenting the const-block layout strategy (rules a–f) and the I2C first-message bug workaround.
