### PR TITLE
Add VESC Express native lib package support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "c_libs/express/RVfplib"]
+	path = c_libs/express/RVfplib
+	url = https://github.com/pulp-platform/RVfplib.git

--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ make clean
 make VESC_TOOL=/path/to/vesc_tool
 ```
 
+### Native libraries for the VESC Express
+
+The build rules for VESC Express native libraries (see `c_libs/examples/express_extension`) use [RVfplib](https://github.com/pulp-platform/RVfplib) for soft-float support on the RISC-V targets. It is included as a git submodule, so it has to be initialized before building:
+```sh
+git submodule update --init
+```
+
 ### Notes
 
 * Make sure that you build a VESC Package file (\*.vescpkg) in the main directory of your package (e.g. euc/euc.vescpkg)

--- a/c_libs/examples/express_extension/.gitignore
+++ b/c_libs/examples/express_extension/.gitignore
@@ -1,0 +1,8 @@
+*.o
+*.d
+*.elf
+*.list
+*.map
+express_extension_*.bin
+express_extension_*.lisp
+express_extension.vescpkg

--- a/c_libs/examples/express_extension/Makefile
+++ b/c_libs/examples/express_extension/Makefile
@@ -1,0 +1,40 @@
+# Native lib example for the VESC Express. Native libs only run on the
+# chip they were built for, so the library is built once per target.
+#
+#   make        - build the lib for all supported chips
+#   make pkg    - also build express_extension.vescpkg (needs vesc_tool)
+#   make clean
+
+VESC_TOOL ?= vesc_tool
+ESP_TARGETS = esp32c3 esp32c6 esp32s3 esp32p4
+
+ifdef ESP_TARGET
+# Recursive invocation: build one target's lib via the common rules.
+ARCH = esp32
+TARGET = express_extension_$(ESP_TARGET)
+SOURCES = code.c
+
+VESC_C_LIB_PATH=../../
+include $(VESC_C_LIB_PATH)rules.mk
+else
+all: libs
+
+# Objects are not target-suffixed, so they are removed between targets.
+libs:
+	for t in $(ESP_TARGETS); do \
+		rm -f *.o *.d; \
+		$(MAKE) ESP_TARGET=$$t || exit 1; \
+	done
+	rm -f *.o *.d
+
+pkg: libs
+	$(VESC_TOOL) --buildPkg "express_extension.vescpkg:express_extension.lisp::0:README.md:Express Native Lib Example"
+
+clean:
+	for t in $(ESP_TARGETS); do \
+		$(MAKE) ESP_TARGET=$$t clean; \
+	done
+	rm -f express_extension.vescpkg
+
+.PHONY: all libs pkg clean
+endif

--- a/c_libs/examples/express_extension/README.md
+++ b/c_libs/examples/express_extension/README.md
@@ -1,0 +1,38 @@
+# Express Native Lib Example
+
+Example native library (C extensions) for the VESC Express. It builds the same small C library for every supported chip (ESP32-C3, C6, S3 and P4), picks the right binary at runtime with `(sysinfo 'hw-target)` and runs a short self-test that prints to the LispBM console.
+
+The library exercises the parts of the C interface that differ between the targets:
+
+* `(ext-test-hello)` - prints a string (rodata addressing; on the S3 this verifies the DRAM-alias relocation of string pointers).
+* `(ext-test-mul a b)` - float multiply (soft float via RVfplib on C3/C6, hardware FPU on S3/P4 - a wrong ABI shows up here).
+* `(ext-test-counter)` - value of a counter incremented every 100 ms by a thread the lib spawns (spawn/terminate and the ARG base-address bookkeeping; on the S3 this verifies the IRAM-alias relocation of code pointers).
+
+## Expected output when the package starts
+
+```
+Loading native test lib for esp32c3
+Native test lib loaded
+t
+Hello from the native test lib!
+2.5 * 3.0 = 7.500000
+Counter after 1s (expect ~10): 10
+```
+
+Restarting or stopping the lisp script should print `Test lib stopped, counter was ...`, which verifies the stop function and thread termination.
+
+## Building
+
+```sh
+make
+```
+
+builds the library for all four chips (needs the `riscv32-esp-elf` and `xtensa-esp32s3-elf` toolchains in the path and the `c_libs/express/RVfplib` submodule initialized: `git submodule update --init`).
+
+```sh
+make pkg
+```
+
+## Requirements
+
+Firmware with native lib support, including `(sysinfo 'hw-target)`. On the ESP32-S3 the firmware must be built with `CONFIG_ESP_SYSTEM_MEMPROT_FEATURE=n`.

--- a/c_libs/examples/express_extension/code.c
+++ b/c_libs/examples/express_extension/code.c
@@ -1,0 +1,115 @@
+/*
+	Copyright 2026 VESC project
+
+	This file is part of the VESC firmware.
+
+	The VESC firmware is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The VESC firmware is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Minimal test library for native lib loading on the VESC Express. It
+// exercises the parts of the C interface that differ between targets:
+// printf and string handling (data addressing), float math (soft float on
+// C3/C6, FPU on S3/P4), malloc + the ARG mechanism (base address
+// bookkeeping) and thread spawn/terminate.
+
+#include "express/vesc_c_if.h"
+
+HEADER
+
+typedef struct {
+	lib_thread thread;
+	int counter;
+} test_state;
+
+static void test_thd(void *arg) {
+	test_state *state = (test_state*)arg;
+
+	while (!VESC_IF->should_terminate()) {
+		state->counter++;
+		VESC_IF->sleep_ms(100);
+	}
+}
+
+// (ext-test-hello) -> t. Prints a string, exercising rodata addressing.
+static lbm_value ext_test_hello(lbm_value *args, lbm_uint argn) {
+	(void)args; (void)argn;
+	VESC_IF->printf("Hello from the native test lib!");
+	return VESC_IF->lbm_enc_sym_true;
+}
+
+// (ext-test-mul a b) -> a * b as float. Exercises the float ABI, which
+// must match the firmware (soft float on C3/C6, hard float on S3/P4).
+static lbm_value ext_test_mul(lbm_value *args, lbm_uint argn) {
+	if (argn != 2 || !VESC_IF->lbm_is_number(args[0])
+		|| !VESC_IF->lbm_is_number(args[1])) {
+		return VESC_IF->lbm_enc_sym_terror;
+	}
+
+	float a = VESC_IF->lbm_dec_as_float(args[0]);
+	float b = VESC_IF->lbm_dec_as_float(args[1]);
+
+	return VESC_IF->lbm_enc_float(a * b);
+}
+
+// (ext-test-counter) -> i. Value of the counter the lib thread increments
+// every 100 ms. Exercises spawn, thread-local terminate state and the
+// ARG/get_arg base address bookkeeping.
+static lbm_value ext_test_counter(lbm_value *args, lbm_uint argn) {
+	(void)args; (void)argn;
+
+	test_state *state = (test_state*)ARG;
+	if (!state) {
+		VESC_IF->lbm_set_error_reason("Not initialized");
+		return VESC_IF->lbm_enc_sym_eerror;
+	}
+
+	return VESC_IF->lbm_enc_i(state->counter);
+}
+
+static void stop(void *arg) {
+	test_state *state = (test_state*)arg;
+
+	if (state) {
+		VESC_IF->request_terminate(state->thread);
+		VESC_IF->printf("Test lib stopped, counter was %d", state->counter);
+		VESC_IF->free(state);
+	}
+}
+
+INIT_FUN(lib_info *info) {
+	INIT_START
+
+	test_state *state = VESC_IF->malloc(sizeof(test_state));
+	if (!state) {
+		return false;
+	}
+
+	state->counter = 0;
+	state->thread = VESC_IF->spawn(test_thd, 2048, "lib_test", state);
+	if (!state->thread) {
+		VESC_IF->free(state);
+		return false;
+	}
+
+	VESC_IF->lbm_add_extension("ext-test-hello", ext_test_hello);
+	VESC_IF->lbm_add_extension("ext-test-mul", ext_test_mul);
+	VESC_IF->lbm_add_extension("ext-test-counter", ext_test_counter);
+
+	info->arg = state;
+	info->stop_fun = stop;
+
+	VESC_IF->printf("Native test lib loaded");
+
+	return true;
+}

--- a/c_libs/examples/express_extension/express_extension.lisp
+++ b/c_libs/examples/express_extension/express_extension.lisp
@@ -1,0 +1,28 @@
+(import "express_extension_esp32c3.bin" 'lib-esp32c3)
+(import "express_extension_esp32c6.bin" 'lib-esp32c6)
+(import "express_extension_esp32s3.bin" 'lib-esp32s3)
+(import "express_extension_esp32p4.bin" 'lib-esp32p4)
+
+; Native libs only run on the chip they were built for, so pick the
+; binary matching this hardware. Requires firmware with support for
+; (sysinfo 'hw-target).
+(def target (sysinfo 'hw-target))
+
+(def lib (cond
+    ((= (str-cmp target "esp32c3") 0) lib-esp32c3)
+    ((= (str-cmp target "esp32c6") 0) lib-esp32c6)
+    ((= (str-cmp target "esp32s3") 0) lib-esp32s3)
+    ((= (str-cmp target "esp32p4") 0) lib-esp32p4)
+    (t nil)
+))
+
+(if (eq lib nil)
+    (print (str-merge "No native test lib for target " target))
+{
+    (print (str-merge "Loading native test lib for " target))
+    (print (load-native-lib lib))
+    (ext-test-hello)
+    (print (str-merge "2.5 * 3.0 = " (str-from-n (ext-test-mul 2.5 3.0))))
+    (sleep 1)
+    (print (str-merge "Counter after 1s (expect ~10): " (str-from-n (ext-test-counter))))
+})

--- a/c_libs/express/link_esp32.ld
+++ b/c_libs/express/link_esp32.ld
@@ -1,0 +1,11 @@
+SECTIONS
+{
+    . = 0;
+    .program_ptr : ALIGN(4) { *(.program_ptr) } /* offset 0 */
+    .init_fun : ALIGN(4) { *(.init_fun) }
+
+    .text : ALIGN(4) { *(.text*) *(.rodata*) }
+    .data : ALIGN(4) { *(.data*) }
+    .bss : ALIGN(4) { *(.bss*) }
+    .got : ALIGN(4) { *(.got*) }
+}

--- a/c_libs/express/link_esp32s3.ld
+++ b/c_libs/express/link_esp32s3.ld
@@ -1,0 +1,29 @@
+/* Linker script for ESP32-S3 (Xtensa) native libraries.
+ *
+ * Unlike the RISC-V targets, Xtensa cannot generate position-independent
+ * code, so S3 libraries are linked at 0 with relocations kept (ld -q) and
+ * the firmware copies them into RAM, patching every absolute word at load
+ * time (see mkreloc.py). Code and data must live in separate output
+ * sections: words that point at executable sections are patched with the
+ * IRAM alias of the load address and everything else with the byte-
+ * accessible DRAM alias.
+ */
+
+/* The image is loaded in two parts: the code region (executable RAM,
+   word-access only is fine) and the data region (byte-accessible RAM).
+   Code sections come first, then the data sections with .program_ptr
+   leading the data region (the loader expects it at data base + 4). */
+
+SECTIONS
+{
+    . = 0;
+    /* code region */
+    .init_fun : ALIGN(4) { *(.init_fun.literal) *(.init_fun) }
+    .text : ALIGN(4) { *(.literal) *(.text) *(.literal.*) *(.text.*) }
+
+    /* data region */
+    .program_ptr : ALIGN(4) { *(.program_ptr) }
+    .rodata : ALIGN(4) { *(.rodata*) *(.srodata*) }
+    .data : ALIGN(4) { *(.data*) *(.sdata*) }
+    .bss : ALIGN(4) { *(.bss*) *(.sbss*) *(COMMON) }
+}

--- a/c_libs/express/mkreloc.py
+++ b/c_libs/express/mkreloc.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# Package an ESP32-S3 (Xtensa) native library into a relocatable container.
+#
+# Xtensa cannot generate position-independent code: address constants are
+# stored as absolute words (R_XTENSA_32) in literal pools and data. The
+# library is therefore linked at address 0 with relocations kept (ld -q),
+# and the firmware copies the image into RAM and adds the load address to
+# every such word at load time. Words that point into executable sections
+# get the IRAM alias of the load address, all others the byte-accessible
+# DRAM alias (on the S3 the same RAM is mapped at both).
+#
+# Container layout (all little-endian u32):
+#   magic        0xCAFEBABF (NATIVE_LIB_RELOC_MAGIC)
+#   image_size   size of image[] in bytes
+#   entry_offset offset of the init function inside image[]
+#   reloc_count  number of entries in relocs[]
+#   relocs[]     (image_offset & 0x7FFFFFFF) | 0x80000000 if the word
+#                points into an executable section
+#   image[]      0xCAFEBABE magic word followed by the raw binary
+#                (ELF VMA v lives at image offset v + 4)
+#
+# Usage: mkreloc.py <lib.elf> <lib_raw.bin> <out.bin>
+
+import struct
+import sys
+
+R_XTENSA_NONE = 0
+R_XTENSA_32 = 1
+R_XTENSA_ASM_EXPAND = 11
+R_XTENSA_ASM_SIMPLIFY = 12
+R_XTENSA_SLOT0_OP = 20
+
+# Types that need no load-time patching: PC-relative or informational
+# (the ASM_* types just annotate longcall sequences for linker relaxation).
+NO_PATCH_TYPES = {R_XTENSA_NONE, R_XTENSA_ASM_EXPAND, R_XTENSA_ASM_SIMPLIFY,
+                  R_XTENSA_SLOT0_OP}
+
+SHF_ALLOC = 0x2
+SHF_EXECINSTR = 0x4
+SHT_RELA = 4
+SHT_SYMTAB = 2
+
+NATIVE_LIB_MAGIC = 0xCAFEBABE
+NATIVE_LIB_RELOC_MAGIC = 0xCAFEBABF
+
+
+def fail(msg):
+    sys.stderr.write("mkreloc.py: error: %s\n" % msg)
+    sys.exit(1)
+
+
+def read_elf(path):
+    data = open(path, "rb").read()
+    if data[:4] != b"\x7fELF" or data[4] != 1 or data[5] != 1:
+        fail("%s is not a little-endian ELF32 file" % path)
+    e_shoff, = struct.unpack_from("<I", data, 0x20)
+    e_shentsize, e_shnum, e_shstrndx = struct.unpack_from("<HHH", data, 0x2E)
+
+    sections = []
+    for i in range(e_shnum):
+        off = e_shoff + i * e_shentsize
+        (sh_name, sh_type, sh_flags, sh_addr, sh_offset, sh_size, sh_link,
+         sh_info, _sh_addralign, sh_entsize) = struct.unpack_from("<10I", data, off)
+        sections.append({
+            "name_off": sh_name, "type": sh_type, "flags": sh_flags,
+            "addr": sh_addr, "offset": sh_offset, "size": sh_size,
+            "link": sh_link, "info": sh_info, "entsize": sh_entsize,
+        })
+
+    shstr = sections[e_shstrndx]
+    for s in sections:
+        end = data.index(b"\x00", shstr["offset"] + s["name_off"])
+        s["name"] = data[shstr["offset"] + s["name_off"]:end].decode()
+
+    return data, sections
+
+
+def main():
+    if len(sys.argv) != 4:
+        fail("usage: mkreloc.py <lib.elf> <lib_raw.bin> <out.bin>")
+    elf_path, bin_path, out_path = sys.argv[1:4]
+
+    data, sections = read_elf(elf_path)
+    image_bin = open(bin_path, "rb").read()
+
+    alloc_sections = [s for s in sections if s["flags"] & SHF_ALLOC and s["size"] > 0]
+
+    def addr_is_exec(addr):
+        for s in alloc_sections:
+            if s["addr"] <= addr < s["addr"] + s["size"]:
+                return bool(s["flags"] & SHF_EXECINSTR)
+        # Allow pointers to the very end of a section (one-past-the-end).
+        for s in alloc_sections:
+            if addr == s["addr"] + s["size"]:
+                return bool(s["flags"] & SHF_EXECINSTR)
+        fail("relocation target 0x%X is outside every allocated section" % addr)
+
+    # Symbol tables, keyed by section index.
+    symtabs = {}
+    for i, s in enumerate(sections):
+        if s["type"] == SHT_SYMTAB:
+            syms = []
+            count = s["size"] // 16
+            for j in range(count):
+                st_name, st_value, st_size, st_info, st_other, st_shndx = \
+                    struct.unpack_from("<IIIBBH", data, s["offset"] + j * 16)
+                syms.append({"name_off": st_name, "value": st_value,
+                             "shndx": st_shndx, "strtab": s["link"]})
+            symtabs[i] = syms
+
+    def sym_name(symtab_idx, sym):
+        strtab = sections[symtabs_link[symtab_idx]]
+        end = data.index(b"\x00", strtab["offset"] + sym["name_off"])
+        return data[strtab["offset"] + sym["name_off"]:end].decode()
+
+    symtabs_link = {i: sections[i]["link"] for i in symtabs}
+
+    # Find the entry symbol.
+    entry_vma = None
+    for i, syms in symtabs.items():
+        for sym in syms:
+            if sym["name_off"] and sym_name(i, sym) == "init":
+                entry_vma = sym["value"]
+    if entry_vma is None:
+        fail("no 'init' symbol in %s" % elf_path)
+    if entry_vma & 3:
+        fail("init is not 4-byte aligned (0x%X)" % entry_vma)
+
+    # Region split: executable sections form the code region at the start
+    # of the address space, everything else (led by .program_ptr) the data
+    # region. The loader places them in different kinds of RAM: code in
+    # any executable block (word-access only), data in any byte-accessible
+    # block. Stored words are rewritten to region-relative offsets so the
+    # loader just adds the matching region base.
+    exec_secs = [s for s in alloc_sections if s["flags"] & SHF_EXECINSTR]
+    data_secs = [s for s in alloc_sections if not s["flags"] & SHF_EXECINSTR]
+    if not exec_secs or not data_secs:
+        fail("expected both code and data sections")
+
+    code_end = max(s["addr"] + s["size"] for s in exec_secs)
+    data_start = min(s["addr"] for s in data_secs)
+    data_end = max(s["addr"] + s["size"] for s in data_secs)
+    if data_start < code_end:
+        fail("data sections overlap the code region - check link_esp32s3.ld "
+             "section order")
+    for s in exec_secs:
+        if s["addr"] + s["size"] > data_start:
+            fail("code section %s extends into the data region" % s["name"])
+    pp = [s for s in data_secs if s["name"] == ".program_ptr"]
+    if not pp or pp[0]["addr"] != data_start:
+        fail(".program_ptr must lead the data region")
+
+    if entry_vma >= code_end:
+        fail("init is not in the code region")
+
+    code_size = (code_end + 3) & ~3
+    data_size = ((data_end - data_start + 3) & ~3) + 4  # + inner magic
+
+    def region_of(addr):
+        # One-past-the-end pointers of the last code section still count
+        # as code; anything from data_start on is data.
+        if addr <= code_end:
+            return "code", addr
+        if data_start <= addr <= data_end:
+            return "data", addr - data_start + 4
+        fail("address 0x%X falls between the code and data regions" % addr)
+
+    # The linker fully resolves every R_XTENSA_32 word in the binary, but
+    # the relocation entries emitted by ld -q can carry stale addends (not
+    # adjusted for input-section placement). So the relocation entry is
+    # only trusted for WHERE an absolute word lives (r_offset); the target
+    # address is read from the resolved word itself.
+    image_bin = bytearray(image_bin)
+    if len(image_bin) < data_end:
+        image_bin += b"\x00" * (data_end - len(image_bin))  # .bss
+
+    relocs = []
+    for s in sections:
+        if s["type"] != SHT_RELA:
+            continue
+        target = sections[s["info"]]
+        if not target["flags"] & SHF_ALLOC:
+            continue
+        count = s["size"] // 12
+        for j in range(count):
+            r_offset, r_info, _r_addend = struct.unpack_from(
+                "<IIi", data, s["offset"] + j * 12)
+            r_type = r_info & 0xFF
+            if r_type in NO_PATCH_TYPES:
+                continue
+            if r_type != R_XTENSA_32:
+                fail("unsupported relocation type %d at 0x%X in %s "
+                     "(cannot be fixed up at load time)"
+                     % (r_type, r_offset, s["name"]))
+
+            if r_offset & 3:
+                fail("R_XTENSA_32 at unaligned offset 0x%X" % r_offset)
+            if r_offset + 4 > len(image_bin):
+                fail("relocation at 0x%X is outside the binary" % r_offset)
+
+            target_addr, = struct.unpack_from("<I", image_bin, r_offset)
+            tgt_region, tgt_off = region_of(target_addr)
+            site_region, site_off = region_of(r_offset)
+            if site_off >= 1 << 30:
+                fail("relocation offset 0x%X too large" % site_off)
+
+            # Rewrite the word to its region-relative target offset.
+            struct.pack_into("<I", image_bin, r_offset, tgt_off)
+
+            entry = site_off
+            if site_region == "data":
+                entry |= 0x40000000
+            if tgt_region == "code":
+                entry |= 0x80000000
+            relocs.append(entry)
+
+    relocs = sorted(set(relocs), key=lambda e: e & 0x7FFFFFFF)
+    offs = [(e & 0x7FFFFFFF) for e in relocs]
+    if len(offs) != len(set(offs)):
+        fail("conflicting classification for one relocation offset")
+
+    code_img = bytes(image_bin[:code_end])
+    code_img += b"\x00" * (code_size - len(code_img))
+    # Magic words are stored as big-endian bytes (CA FE BA Bx), matching
+    # the existing XIP container convention. The data region carries the
+    # inner magic so prog_ptr lands at data base + 4.
+    data_img = struct.pack(">I", NATIVE_LIB_MAGIC) \
+        + bytes(image_bin[data_start:data_end])
+    data_img += b"\x00" * (data_size - len(data_img))
+
+    out = struct.pack(">I", NATIVE_LIB_RELOC_MAGIC)
+    out += struct.pack("<5I", 2, code_size, data_size, entry_vma, len(relocs))
+    out += b"".join(struct.pack("<I", e) for e in relocs)
+    out += code_img
+    out += data_img
+
+    open(out_path, "wb").write(out)
+    print("mkreloc.py: %s: code %d B, data %d B, entry at 0x%X, %d relocations"
+          % (out_path, code_size, data_size, entry_vma, len(relocs)))
+
+
+if __name__ == "__main__":
+    main()

--- a/c_libs/express/vesc_c_if.h
+++ b/c_libs/express/vesc_c_if.h
@@ -1,0 +1,277 @@
+/*
+	Copyright 2022 Benjamin Vedder	benjamin@vedder.se
+
+	This file is part of the VESC firmware.
+
+	The VESC firmware is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The VESC firmware is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Native library C interface for the VESC Express.
+ *
+ * This is a NEW interface, separate from the bldc (STM32 motor controller)
+ * vesc_c_if. It starts from the platform-neutral core - LispBM access,
+ * threads, timing, mutexes/semaphores, memory and printf - and contains no
+ * motor, CAN or peripheral functions. More slots will be appended over time.
+ *
+ * Compatibility rules:
+ *  - New function pointers are ONLY ever added at the END of the struct, so
+ *    libs built against older headers keep working on newer firmware. Added
+ *    slots are null-pointers on firmware that predates them - a lib that
+ *    wants to run on older firmware can check them for NULL.
+ *  - VESC_C_IF_VERSION is bumped ONLY on a breaking layout change. INIT_START
+ *    compares it against the firmware's table (first slot, read before any
+ *    function in the table is called) and fails the lib init on mismatch.
+ */
+
+#ifndef VESC_C_IF_H
+#define VESC_C_IF_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+// Layout version of the vesc_c_if struct below. Only bumped on breaking
+// changes; appended slots do NOT bump it.
+#define VESC_C_IF_VERSION 1
+
+#define NATIVE_LIB_MAGIC 0xCAFEBABE
+
+// Container magic for relocatable libs that the firmware copies into RAM
+// and patches at load time. Used on targets that cannot run position-
+// independent code in place (ESP32-S3 / Xtensa). Layout: magic,
+// version, code_size, data_size, entry_offset, reloc_count, relocs[],
+// code[], data[].
+#define NATIVE_LIB_RELOC_MAGIC 0xCAFEBABF
+
+// System tick, as returned by system_time_ticks
+typedef uint32_t systime_t;
+
+#ifdef IS_VESC_LIB
+// LBM types, provided by lispbm.h when compiling the firmware itself.
+typedef uint32_t lbm_value;
+typedef uint32_t lbm_type;
+typedef uint32_t lbm_cid;
+
+typedef uint32_t lbm_uint;
+typedef int32_t  lbm_int;
+typedef float    lbm_float;
+
+typedef struct {
+	uint8_t *buf;
+	lbm_uint buf_size;
+	lbm_uint buf_pos;
+} lbm_flat_value_t;
+
+typedef struct {
+	lbm_uint size;            /// Number of elements
+	lbm_uint *data;           /// pointer to lbm_memory array or C array.
+} lbm_array_header_t;
+
+typedef lbm_value (*extension_fptr)(lbm_value*,lbm_uint);
+
+// For double precision literals
+#define D(x) 				((double)x##L)
+#endif
+
+typedef bool (*load_extension_fptr)(char*,extension_fptr);
+
+typedef void* lib_thread;
+typedef void* lib_mutex;
+typedef void* lib_semaphore;
+
+/*
+ * Function pointer struct. Always add new function pointers to the end in
+ * order to not break compatibility with old binaries. If a function is not
+ * available (e.g. in an old firmware) it will be a null-pointer.
+ */
+typedef struct {
+	// Interface layout version, always the first slot. Read by INIT_START
+	// before anything else in the table is used.
+	uint32_t if_version;
+
+	// LBM: extensions, symbols and errors
+	load_extension_fptr lbm_add_extension;
+	int (*lbm_set_error_reason)(char *str);
+	int (*lbm_add_symbol_const)(const char *, lbm_uint *);
+	int (*lbm_get_symbol_by_name)(const char *name, lbm_uint* id);
+
+	// LBM: evaluator control and messaging
+	void (*lbm_block_ctx_from_extension)(void);
+	bool (*lbm_unblock_ctx)(lbm_cid, lbm_flat_value_t*);
+	bool (*lbm_unblock_ctx_unboxed)(lbm_cid cid, lbm_value unboxed);
+	lbm_cid (*lbm_get_current_cid)(void);
+	int (*lbm_send_message)(lbm_cid cid, lbm_value msg);
+	void (*lbm_pause_eval_with_gc)(uint32_t num_free);
+	void (*lbm_continue_eval)(void);
+	bool (*lbm_eval_is_paused)(void);
+
+	// LBM: heap and values
+	lbm_value (*lbm_cons)(lbm_value car, lbm_value cdr);
+	lbm_value (*lbm_car)(lbm_value val);
+	lbm_value (*lbm_cdr)(lbm_value val);
+	lbm_value (*lbm_list_destructive_reverse)(lbm_value list);
+	bool (*lbm_create_byte_array)(lbm_value *value, lbm_uint num_elt);
+
+	// LBM: encoding
+	lbm_value (*lbm_enc_i)(lbm_int x);
+	lbm_value (*lbm_enc_u)(lbm_uint x);
+	lbm_value (*lbm_enc_char)(uint8_t x);
+	lbm_value (*lbm_enc_float)(float f);
+	lbm_value (*lbm_enc_u32)(uint32_t u);
+	lbm_value (*lbm_enc_i32)(int32_t i);
+	lbm_value (*lbm_enc_sym)(lbm_uint s);
+
+	// LBM: decoding
+	float (*lbm_dec_as_float)(lbm_value val);
+	uint32_t (*lbm_dec_as_u32)(lbm_value val);
+	int32_t (*lbm_dec_as_i32)(lbm_value val);
+	uint8_t (*lbm_dec_char)(lbm_value x);
+	char* (*lbm_dec_str)(lbm_value);
+	lbm_uint (*lbm_dec_sym)(lbm_value x);
+
+	// LBM: type checks
+	bool (*lbm_is_byte_array)(lbm_value val);
+	bool (*lbm_is_cons)(lbm_value x);
+	bool (*lbm_is_number)(lbm_value x);
+	bool (*lbm_is_char)(lbm_value x);
+	bool (*lbm_is_symbol)(lbm_value x);
+	bool (*lbm_is_symbol_nil)(lbm_uint);
+	bool (*lbm_is_symbol_true)(lbm_uint);
+
+	// LBM: symbol constants
+	lbm_uint lbm_enc_sym_nil;
+	lbm_uint lbm_enc_sym_true;
+	lbm_uint lbm_enc_sym_terror;
+	lbm_uint lbm_enc_sym_eerror;
+	lbm_uint lbm_enc_sym_merror;
+
+	// LBM: flat values
+	bool (*lbm_start_flatten)(lbm_flat_value_t *v, size_t buffer_size);
+	bool (*lbm_finish_flatten)(lbm_flat_value_t *v);
+	bool (*f_cons)(lbm_flat_value_t *v);
+	bool (*f_sym)(lbm_flat_value_t *v, lbm_uint sym);
+	bool (*f_i)(lbm_flat_value_t *v, lbm_int i);
+	bool (*f_b)(lbm_flat_value_t *v, uint8_t b);
+	bool (*f_i32)(lbm_flat_value_t *v, int32_t w);
+	bool (*f_u32)(lbm_flat_value_t *v, uint32_t w);
+	bool (*f_float)(lbm_flat_value_t *v, float f);
+	bool (*f_i64)(lbm_flat_value_t *v, int64_t w);
+	bool (*f_u64)(lbm_flat_value_t *v, uint64_t w);
+	bool (*f_lbm_array)(lbm_flat_value_t *v, uint32_t num_elts, uint8_t *data);
+
+	// Os: time and sleep
+	void (*sleep_ms)(uint32_t ms);
+	void (*sleep_us)(uint32_t us);
+	float (*system_time)(void); // Time since boot in seconds
+	float (*ts_to_age_s)(systime_t ts); // Age of timestamp in seconds
+	// Time since boot in system ticks (see SYSTEM_TICK_RATE_HZ). Use
+	// ts_to_age_s to get the age of a timestamp in seconds; it handles
+	// overflows.
+	systime_t (*system_time_ticks)(void);
+	void (*sleep_ticks)(systime_t ticks);
+	// High resolution timer for short busy-wait sleeps and time
+	// measurement, in microseconds.
+	uint32_t (*timer_time_now)(void);
+	float (*timer_seconds_elapsed_since)(uint32_t time);
+	void (*timer_sleep)(float seconds);
+
+	// Os: memory and IO
+	int (*printf)(const char *str, ...);
+	void* (*malloc)(size_t bytes);
+	void (*free)(void *ptr);
+
+	// Os: threads
+	lib_thread (*spawn)(void (*fun)(void *arg), size_t stack_size, const char *name, void *arg);
+	void (*request_terminate)(lib_thread thd);
+	bool (*should_terminate)(void);
+	// Set priority of current thread.
+	// Range: -5 to 5, -5 is lowest, 0 is normal, 5 is highest
+	void (*thread_set_priority)(int priority);
+	void** (*get_arg)(uint32_t prog_addr);
+
+	// Os: mutex
+	lib_mutex (*mutex_create)(void); // Use VESC_IF->free on the mutex when done with it
+	void (*mutex_lock)(lib_mutex);
+	void (*mutex_unlock)(lib_mutex);
+
+	// Os: semaphore
+	lib_semaphore (*sem_create)(void); // Use VESC_IF->free on the semaphore when done with it
+	void (*sem_wait)(lib_semaphore);
+	void (*sem_signal)(lib_semaphore);
+	bool (*sem_wait_to)(lib_semaphore, systime_t); // Returns false on timeout
+	void (*sem_reset)(lib_semaphore);
+} vesc_c_if;
+
+typedef struct {
+	void (*stop_fun)(void *arg);
+	void *arg;
+	uint32_t base_addr;
+} lib_info;
+
+// System tick rate. Can be used to convert system ticks to time
+#define SYSTEM_TICK_RATE_HZ 1000
+
+/*
+ * Address of the firmware-side C interface table. It must match the address
+ * of the .libif section in main/linker_libif_<target>.ld for the target the
+ * firmware (and the native library) is built for.
+ *
+ * The firmware build picks the target up from sdkconfig automatically. When
+ * building a native library out of tree, define the CONFIG_IDF_TARGET_*
+ * macro matching the hardware you are building for, e.g.
+ * -DCONFIG_IDF_TARGET_ESP32C3=1. A library only works on the target it was
+ * built for.
+ */
+#if defined(__has_include)
+#if __has_include("sdkconfig.h")
+#include "sdkconfig.h"
+#endif
+#endif
+
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+#define VESC_IF		((vesc_c_if*)(0x3FCDBE00))
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+#define VESC_IF		((vesc_c_if*)(0x3FCE8800))
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+#define VESC_IF		((vesc_c_if*)(0x4087B800))
+#elif defined(CONFIG_IDF_TARGET_ESP32P4)
+#define VESC_IF		((vesc_c_if*)(0x4FF3A000))
+#else
+#error "Unknown ESP target. Define CONFIG_IDF_TARGET_ESP32C3, -S3, -C6 or -P4 when building a native library."
+#endif
+
+// Put this at the beginning of your source file
+#define HEADER		volatile int __attribute__((__section__(".program_ptr"))) prog_ptr;
+
+// Init function
+#define INIT_FUN	bool __attribute__((__section__(".init_fun"))) init
+
+// Put this at the start of the init function. The version check reads the
+// first table slot only - safe even when the firmware carries a different
+// interface layout.
+#define INIT_START	(void)prog_ptr; \
+					if (VESC_IF->if_version != VESC_C_IF_VERSION) { \
+						return false; \
+					}
+
+// Address of this program in memory
+#define PROG_ADDR	((uint32_t)&prog_ptr)
+
+// The argument that was set in the init function (same as the one you get in stop_fun)
+#define ARG			(*VESC_IF->get_arg(PROG_ADDR))
+
+extern volatile int prog_ptr;
+
+#endif  // VESC_C_IF_H

--- a/c_libs/rules.mk
+++ b/c_libs/rules.mk
@@ -1,3 +1,15 @@
+# ======================================================================
+# Unified Makefile for STM32F4 (default) and ESP32-C3 (minimal)
+# ======================================================================
+
+# ------------------------- Arch selection ------------------------------
+ARCH ?= stm32
+ifeq ($(ESP_PLATFORM),true)
+  ARCH := esp32
+endif
+
+# CROSS prefix per arch (override if you like)
+ifeq ($(ARCH),stm32)
 
 CC = arm-none-eabi-gcc
 LD = arm-none-eabi-gcc
@@ -67,4 +79,247 @@ $(TARGET): $(OBJECTS)
 
 clean:
 	rm -f $(OBJECTS) $(TARGET).elf $(TARGET).list $(TARGET).lisp $(TARGET).bin
+else ifeq ($(ARCH),esp32)
+# ======================================================================
+#  VESC Express   Native-lib rules (PIC blob for LispBM)
+#  - RISC-V targets (esp32c3 default, esp32c6, esp32p4): position-
+#    independent blob, executed in place from flash (XIP). Writes to
+#    .data/.bss do not work - keep state in allocated memory. Statically
+#    initialized POINTERS (e.g. const char *tab[] = {"a", ...}) hold
+#    meaningless link-time addresses at runtime - store names as
+#    fixed-size char arrays and use index/offset tables instead.
+#  - Xtensa target (esp32s3): Xtensa cannot generate position-independent
+#    code, so the lib is linked at 0 with relocations kept and packaged
+#    with a relocation table (mkreloc.py). The firmware copies it into
+#    RAM and patches it at load time. .data/.bss work on this target.
+#  - march/mabi must match the firmware ABI of the chip, and the
+#    resulting binary only runs on the chip it was built for
+#  - Section GC + (optional) LTO
+#  - Generates: .elf, .bin (with header), .lisp, .list, .map
+# ======================================================================
 
+# ---- target chip selection ---------------------------------------------
+ESP_TARGET ?= esp32c3
+
+ifeq ($(ESP_TARGET),esp32c3)
+  LOAD_MODEL     := xip
+  ARCH_CFLAGS    := -march=rv32imc_zicsr_zifencei -mabi=ilp32
+  ESP_TARGET_DEF := CONFIG_IDF_TARGET_ESP32C3
+  USE_RVFP       := yes
+else ifeq ($(ESP_TARGET),esp32c6)
+  LOAD_MODEL     := xip
+  ARCH_CFLAGS    := -march=rv32imac_zicsr_zifencei -mabi=ilp32
+  ESP_TARGET_DEF := CONFIG_IDF_TARGET_ESP32C6
+  USE_RVFP       := yes
+else ifeq ($(ESP_TARGET),esp32p4)
+  LOAD_MODEL     := xip
+  ARCH_CFLAGS    := -march=rv32imafc_zicsr_zifencei -mabi=ilp32f
+  ESP_TARGET_DEF := CONFIG_IDF_TARGET_ESP32P4
+  USE_RVFP       := no    # hardware single-precision FPU
+else ifeq ($(ESP_TARGET),esp32s3)
+  LOAD_MODEL     := ram
+  ARCH_CFLAGS    :=
+  ESP_TARGET_DEF := CONFIG_IDF_TARGET_ESP32S3
+  USE_RVFP       := no    # hardware single-precision FPU
+else
+  $(error Unknown ESP_TARGET=$(ESP_TARGET); use esp32c3, esp32c6, esp32p4 or esp32s3)
+endif
+
+# Run 'make clean' when switching ESP_TARGET - objects are not
+# target-suffixed.
+
+# ---- toolchain (override CROSS if needed) -----------------------------
+ifeq ($(ESP_TARGET),esp32s3)
+CROSS     ?= xtensa-esp32s3-elf-
+else
+CROSS     ?= riscv32-esp-elf-
+endif
+CC        := $(CROSS)gcc
+AR        := $(CROSS)ar
+OBJDUMP   := $(CROSS)objdump
+OBJCOPY   := $(CROSS)objcopy
+NM        := $(CROSS)nm
+READELF   := $(CROSS)readelf
+PYTHON    ?= python3
+
+# ---- project defaults (override if you like) --------------------------
+TARGET   ?= package_lib
+SOURCES  ?=
+
+# ---- paths ------------------------------------------------------------
+VESC_C_LIB_PATH ?= ../..
+ifeq ($(LOAD_MODEL),ram)
+LINKER_SCRIPT   ?= $(VESC_C_LIB_PATH)/express/link_esp32s3.ld
+else
+LINKER_SCRIPT   ?= $(VESC_C_LIB_PATH)/express/link_esp32.ld
+endif
+
+# ---- RVfplib (soft-float targets only) ---------------------------------
+# Expect RVfplib sources at $(VESC_C_LIB_PATH)/express/RVfplib/
+# Not used on esp32p4, which has a hardware FPU (ilp32f ABI).
+RVFP_SRC_DIR   := $(VESC_C_LIB_PATH)/express/RVfplib
+RVFP_VARIANT   ?= rvfp_nd_s
+ifeq ($(USE_RVFP),yes)
+  RVFP_LIB := $(RVFP_SRC_DIR)/build/lib/lib$(RVFP_VARIANT).a
+else
+  RVFP_LIB :=
+endif
+
+# ---- toggles ----------------------------------------------------------
+USE_LTO      ?= no        # Use LTO if your riscv32-esp-elf toolchain supports it
+VERBOSE_LINK ?= yes       # Emit a link map and (optionally) GC diagnostics
+
+# Exported entry symbols (kept even with GC/LTO)
+ENTRY_SYMS ?= init
+
+# ---- common flags -----------------------------------------------------
+# The VESC Express has its own native lib interface (express/vesc_c_if.h),
+# separate from the bldc vesc_c_if.h - Express libs include it explicitly
+# as "express/vesc_c_if.h".
+CFLAGS_COMMON = \
+  -Os -Wall -Wextra -Wundef -std=gnu99 \
+  -ffunction-sections -fdata-sections \
+  -I$(VESC_C_LIB_PATH) -DIS_VESC_LIB \
+  -DESP_PLATFORM=true \
+  -D$(ESP_TARGET_DEF)=1 \
+  $(ARCH_CFLAGS) \
+  -Wdouble-promotion -Wfloat-conversion \
+  -Werror=implicit-function-declaration \
+  -Werror=incompatible-pointer-types \
+  -Werror=int-conversion \
+  -Werror=return-type
+
+ifeq ($(LOAD_MODEL),ram)
+  # Xtensa: absolute addressing, fixed up at load time. Merged string
+  # sections are disabled because they corrupt emitted relocation addends.
+  CFLAGS_COMMON += -mtext-section-literals -mlongcalls -fno-merge-constants
+else
+  # RISC-V: truly position-independent code, executed in place.
+  CFLAGS_COMMON += -fPIC -fvisibility=hidden \
+    -mno-save-restore -mcmodel=medany -msmall-data-limit=0
+endif
+
+ifeq ($(USE_LTO),yes)
+  CFLAGS_COMMON += -flto
+  LDFLAGS_LTO   = -flto
+else
+  LDFLAGS_LTO   =
+endif
+
+# Dependency generation
+CFLAGS_DEPS = -MMD
+
+CFLAGS += $(CFLAGS_COMMON) $(CFLAGS_DEPS)
+
+# ---- link flags -------------------------------------------------------
+LDFLAGS = \
+  -static \
+  -Wl,--gc-sections \
+  -Wl,--no-warn-rwx-segments \
+  -T $(LINKER_SCRIPT) \
+  -Wl,-Map=$(TARGET).map \
+  $(LDFLAGS_LTO)
+
+ifeq ($(LOAD_MODEL),ram)
+  # Keep relocations in the output so mkreloc.py can build the load-time
+  # fixup table.
+  LDFLAGS += -Wl,-q
+else
+  LDFLAGS += -Wl,--no-relax
+endif
+
+# Keep required entry points
+LDFLAGS += $(foreach s,$(ENTRY_SYMS),-Wl,--undefined=$(s))
+
+ifeq ($(USE_RVFP),yes)
+# Helpful traces (you can comment these out if too chatty)
+LDFLAGS += -Wl,--trace-symbol=__mulsf3 -Wl,--trace-symbol=__divsf3
+LDFLAGS += -Wl,--trace-symbol=__addsf3 -Wl,--trace-symbol=__subsf3
+LDFLAGS += -Wl,--trace-symbol=__eqsf2  -Wl,--trace-symbol=__nesf2
+endif
+
+# Diagnostics
+ifeq ($(VERBOSE_LINK),yes)
+  # Uncomment to see stripped sections:
+  # LDFLAGS += -Wl,--print-gc-sections
+endif
+
+# ---- required soft-float libs (group avoids cyclic deps) --------------
+# Link the locally-built librvfp.a first on soft-float targets
+ifeq ($(USE_RVFP),yes)
+  LDGROUP := -Wl,--start-group $(RVFP_LIB) -Wl,--end-group
+else
+  LDGROUP :=
+endif
+
+# ---- derived names ----------------------------------------------------
+OBJECTS := $(SOURCES:.c=.o)
+DEPS    := $(SOURCES:.c=.d)
+ELF     := $(TARGET).elf
+BIN     := $(TARGET).bin
+LISP    := $(TARGET).lisp
+LIST    := $(TARGET).list
+MAP     := $(TARGET).map
+
+# ---- phony ------------------------------------------------------------
+.PHONY: default all clean nmcheck disasm rvfp
+
+default: $(TARGET)
+all:     default
+
+# ---- auto-build librvfp.a (no checks; assumes RVfplib exists) --------
+ifeq ($(USE_RVFP),yes)
+$(RVFP_LIB):
+	@echo ">> Building RVfplib ($(RVFP_VARIANT)) with $(CROSS)"
+	$(MAKE) -C "$(RVFP_SRC_DIR)" \
+		RISCV_PREFIX=$(CROSS) ARCH=rv32imc ABI=ilp32 \
+		CC=$(CC) AR=$(AR) NM=$(NM) OBJDUMP=$(OBJDUMP)
+endif
+
+rvfp: $(RVFP_LIB)
+
+# ---- build rules ------------------------------------------------------
+ifeq ($(LOAD_MODEL),ram)
+# Xtensa: raw binary + relocation table container (see mkreloc.py)
+$(TARGET): $(ELF)
+	$(OBJCOPY) -O binary --gap-fill 0x00 $< $@.temp
+	$(PYTHON) $(VESC_C_LIB_PATH)/express/mkreloc.py $< $@.temp $@.bin
+	rm $@.temp
+	$(PYTHON) $(VESC_C_LIB_PATH)/conv.py -f $@.bin -n $(TARGET) > $(LISP)
+else
+# RISC-V: XIP image, magic word + raw binary
+$(TARGET): $(ELF)
+	$(OBJCOPY) -O binary $< $@.temp
+	echo 'cafebabe' | xxd -r -p > $@.bin
+	cat $@.temp >> $@.bin
+	rm $@.temp
+	$(PYTHON) $(VESC_C_LIB_PATH)/conv.py -f $@.bin -n $(TARGET) > $(LISP)
+endif
+
+$(ELF): $(OBJECTS) $(RVFP_LIB)
+	$(CC) $(OBJECTS) $(CFLAGS) $(LDFLAGS) $(LDGROUP) -o $@
+	$(OBJDUMP) -D $@ > $(LIST)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJECTS) $(DEPS) $(ELF) $(BIN) $(LISP) $(LIST) $(MAP) $(ADD_TO_CLEAN)
+
+# ---- helpers ----------------------------------------------------------
+nmcheck: $(ELF)
+	@echo "# soft-float helpers present (T=defined, U=undefined):"
+	$(NM) $(ELF) | egrep '__subsf3|__addsf3|__mulsf3|__divsf3|__eqsf2|__nesf2' || true
+	@echo
+	@echo "# relocations against helpers (should usually be none):"
+	$(READELF) -r $(ELF) | egrep '__subsf3|__addsf3|__mulsf3|__divsf3|__eqsf2|__nesf2' || true
+
+disasm: $(ELF)
+	$(OBJDUMP) -drwC --disassemble=buffer_get_float16 $(ELF) | sed -n '1,200p'
+
+# Include auto-generated dependencies
+-include $(DEPS)
+
+else
+  $(error Unknown ARCH=$(ARCH); use stm32 or esp32)
+endif


### PR DESCRIPTION
### Add packaging support for ESP32 based hardware targets

This work builds on top of #64 by adopting the minimal changes required for packaging esp32 chip family native libs based on the current state of the vesc_express repo.

Package builds for express generate binaries for each chip target and are bundled together in the vescpkg file for portability across targets. load-native-lib then takes care of this by only loading the lib for the target chip via (sysinfo 'hw-target)

PR includes a very basic architecture test with an example of how the load is done.

Depends on the following PR for VESC Express firmware support:
[https://github.com/vedderb/vesc_express/pull/107](https://github.com/vedderb/vesc_express/pull/107
)
