### PR TITLE
vbms32_micro.lisp charge-ok fix

### DIFF
--- a/vbms32_micro/vbms32_micro.lisp
+++ b/vbms32_micro/vbms32_micro.lisp
@@ -375,6 +375,8 @@ loopwhile-thd
         (setq init-done true)
 
         (setq charge-ok (and
+                ; charging should only start if the voltage is lower than vc_charge_start
+                (< c-max (bms-get-param 'vc_charge_start))
                 (< c-max (bms-get-param 'vc_charge_end))
                 (> c-min (bms-get-param 'vc_charge_min))
                 (< t-max (bms-get-param 't_charge_max))

--- a/vbms32_micro/vbms32_micro.lisp
+++ b/vbms32_micro/vbms32_micro.lisp
@@ -644,6 +644,8 @@ loopwhile-thd
                             (bms-get-param 'vc_charge_end)
                             (bms-get-param 'vc_charge_start)
                     ))
+                    ; Since vc_charge_start can be set higher than vc_charge_end in VESC tool, we need to always check for that
+                    (< c-max (bms-get-param 'vc_charge_end))
                     (> c-min (bms-get-param 'vc_charge_min))
                     (< t-max (bms-get-param 't_charge_max))
                     (> t-min (bms-get-param 't_charge_min))


### PR DESCRIPTION
Since vc_charge_start can be set higher than vc_charge_end in VESC tool (created an [ISSUE](https://github.com/vedderb/vesc_tool/issues/462) for that), we need to always check for that scenario regardless of charging status + charging should only start if c-max is lower than vc_charge_start.

EDIT: I have some more fixes that might be useful for others but I wouldn't put them inside this official script. Would you accept it if I created a new package, eg "vbms32_micro_mortificator_custom"? Or if you have a different naming convention in mind, let me know.