### PR TITLE
vbms32_micro: set bms-v-cell-max instead of duplicate bms-v-cell-min

### DIFF
--- a/vbms32_micro/vbms32_micro.lisp
+++ b/vbms32_micro/vbms32_micro.lisp
@@ -580,7 +580,7 @@ loopwhile-thd
             (set-bms-val 'bms-data-version 1)
 
             (set-bms-val 'bms-v-cell-min c-min)
-            (set-bms-val 'bms-v-cell-min c-max)
+            (set-bms-val 'bms-v-cell-max c-max)
 
             (if (= (bms-get-param 'soc_use_ah) 1)
                 {


### PR DESCRIPTION
The main-ctrl loop set `bms-v-cell-min` twice, so `bms-v-cell-max` was never written and stayed at its 0.0 default. Matches the correct form already used in vbms32, vbms_harmony16, and vbms_harmony32.

Validated by updating the LISP script on my VBMS-Micro in the 20S pack on my Fungineers X7S board via VESC Tool. 

Figured it was a good idea to fix it upstream as well. 

Closes issue: #108 