### PR TITLE
Fix quirk where constructing new strip would blast full brightness

### DIFF
--- a/lib_esp_led_strip/README.md
+++ b/lib_esp_led_strip/README.md
@@ -12,7 +12,7 @@ The package includes a VESC Tool page for testing. Each LED strip is a tab: use 
 
 | Extension | Args | Notes |
 |---|---|---|
-| `ext-esp_led-seg-def` | `(i pin type len [offset] [timing])` | define segment `i` (type: 0 GRB, 1 RGB, 2 GRBW, 3 RGBW, 4 WRGB - white first, e.g. WS2814. Types 2+ are 4 bytes per pixel). Segments on the same pin form one chained strip; `offset` is the segment's pixel position in the chain. `timing` selects the wire timing: 0 generic (default), 1 WS2812B, 2 WS2815, 3 SK6812, 4 SK6815 |
+| `ext-esp_led-seg-def` | `(i pin type len [offset] [timing])` | define segment `i` (type: 0 GRB, 1 RGB, 2 GRBW, 3 RGBW, 4 WRGB - white first, e.g. WS2814. Types 2+ are 4 bytes per pixel). Segments on the same pin form one chained strip; `offset` is the segment's pixel position in the chain. `timing` selects the wire timing: 0 generic (default), 1 WS2812B, 2 WS2815, 3 SK6812, 4 SK6815. A new segment starts at brightness 0, so it stays dark until you set one - the render thread starts at `ext-esp_led-init`, and anything else would light the strip at full brightness until your first appearance update lands |
 | `ext-esp_led-init` | `(n)` | start rendering the first `n` segments |
 | `ext-esp_led-deinit` | `()` | blank the strips, stop rendering and release the LED driver. The blank matters because the pixels latch: releasing a pin on its own would leave them lit on their last frame |
 | `ext-esp_led-seg-look` | `(i fx pal color spd bri)` | full appearance in one call |

--- a/lib_esp_led_strip/esp_led_strip/code.c
+++ b/lib_esp_led_strip/esp_led_strip/code.c
@@ -829,8 +829,8 @@ static lbm_value ext_seg_def(lbm_value *args, lbm_uint argn) {
 	s->auto_white = false;
 	s->fx = FX_SOLID;
 	s->pal = 1; // Spectrum (0 is the custom palette, empty by default)
-	s->bri = 255;
-	s->bri_cur = 255;
+	s->bri = 0;
+	s->bri_cur = 0;
 	s->spd = esp_led_SPD_DEF;
 	s->size = 8;
 	s->fx_val = 255;

--- a/lib_esp_led_strip/ui.qml
+++ b/lib_esp_led_strip/ui.qml
@@ -54,7 +54,7 @@ Item {
                 readonly property int defSpeed: 32
                     readonly property int defSize: 8
                         readonly property int defFxVal: 255
-                            readonly property int defBri: 255
+                            readonly property int defBri: 0
                             readonly property bool defAutoWhite: false
                             readonly property bool defReverse: false
 
@@ -126,7 +126,7 @@ Item {
                                     pin: pin, len: len, ledType: type, timing: timing, offset: offset,
                                     fx: defFx, pal: defPal,
                                     w: 0, r: 255, g: 0, b: 0,
-                                    speed: defSpeed, size: defSize, fxVal: defFxVal, bri: defBri,
+                                    speed: defSpeed, size: defSize, fxVal: defFxVal, bri: 255,
                                     autoWhite: defAutoWhite, reverse: defReverse
                                 }
                             }


### PR DESCRIPTION
Sorry for the follow-up so close to merging the last PR.

This change allows consumers to init strips without a flash if their initial brightness is less than max