### PR TITLE
blacktip_dpv: fix startup trigger handling and timer rotation

### DIFF
--- a/blacktip_dpv/README.md
+++ b/blacktip_dpv/README.md
@@ -2,7 +2,7 @@
 
 ![Blacktip DPV Logo](https://raw.githubusercontent.com/vedderb/vesc_pkg/main/blacktip_dpv/assets/shark_with_laser.png)
 
-**Version:** 1.5.1
+**Version:** 1.5.2
 
 ## License
 
@@ -37,6 +37,13 @@ Some videos showing the basic commands to control Smart Cruise while diving:
 - [manually enabling and disabling Smart Cruise](https://youtu.be/riwqB_mttLM)
 
 ---
+
+## What's New in Version 1.5.2
+
+Bugfix release:
+
+- **Fix: Trigger input during startup** — Trigger presses held or made before the runtime is ready are ignored, preventing an incomplete start. A release arms the next click sequence as soon as the motor, display and trigger paths are running.
+- **Fix: Smart Cruise timer rotation** — The remaining-time bar now rotates with the display at 90°, 180° and 270°.
 
 ## What's New in Version 1.5.1
 

--- a/blacktip_dpv/README.md
+++ b/blacktip_dpv/README.md
@@ -232,6 +232,8 @@ The existing OFF&#95;AFTER&#95;5H setting remains the fallback when manual shutd
 A distinctive musical theme plays on power-up to confirm successful initialization:
 
 - Plays automatically when the scooter is turned on
+- Trigger input becomes ready as soon as the motor, display and trigger paths have started; the startup and battery sounds continue in the background.
+- The startup display indicates readiness. If the trigger was held during startup, release it once before making a new click sequence.
 - When battery is full (3 bars, >75%), only the startup sound plays
 - When battery is not full (<75%), the startup sound is followed by battery level beeps
 - Volume matches your configured beep volume setting

--- a/blacktip_dpv/blacktip_dpv.lisp
+++ b/blacktip_dpv/blacktip_dpv.lisp
@@ -890,6 +890,16 @@
 {
     (gpio-configure 'pin-ppm 'pin-mode-in-pd)
 
+    ; Sample before main advertises readiness. A released trigger is ready for
+    ; its first click; a held trigger remains blocked until it is released.
+    (if (= 1 (gpio-read 'pin-ppm))
+        (setvar 'sw_pressed 1)
+        (setvar 'sw_pressed 0)
+    )
+    (if (= sw_pressed 0)
+        (setvar 'trigger_armed 1)
+    )
+
     (loopwhile-thd THREAD_STACK_GPIO t {
         (sleep SLEEP_MOTOR_CONTROL)
         (if (= 1 (gpio-read 'pin-ppm))

--- a/blacktip_dpv/blacktip_dpv.lisp
+++ b/blacktip_dpv/blacktip_dpv.lisp
@@ -245,6 +245,8 @@
 ; --- Runtime state machine / motor / display vars ---
 (define sw_state 0)
 (define sw_pressed 0)
+(define trigger_input_ready 0)         ; Ignore input until runtime setup is complete.
+(define trigger_armed 0)               ; Require a release after readiness before accepting clicks.
 (define timer_start 0)
 (define timer_duration 0)
 (define initial_press_time 0)
@@ -892,6 +894,11 @@
             (setvar 'sw_pressed 1)
             (setvar 'sw_pressed 0)
         )
+        ; Do not interpret a press that began before startup completed as a click.
+        ; A released trigger arms input immediately after the ready indication.
+        (if (and (= trigger_input_ready 1) (= sw_pressed 0))
+            (setvar 'trigger_armed 1)
+        )
     })
 })
 
@@ -1111,7 +1118,7 @@
         (setvar 'actual_batt (get_battery_level))
 
         ; Pressed
-        (if (= sw_pressed 1) {
+        (if (and (= trigger_input_ready 1) (= trigger_armed 1) (= sw_pressed 1)) {
             (debug_log "State 0->1: Button pressed")
             (setvar 'batt_disp_timer_start 0) ; Stop Battery Display in case its running
             (setvar 'disp_timer_start 0) ; Stop Display in case its running
@@ -2146,6 +2153,8 @@
     (setup_event_handler)
 
     (setvar 'sw_state 0)
+    (setvar 'trigger_input_ready 0)
+    (setvar 'trigger_armed 0)
     (setvar 'timer_start 0)
     (setvar 'timer_duration 0)
     (setvar 'initial_press_time 0)
@@ -2215,6 +2224,11 @@
     (setvar 'sw_pressed 0)
 
     (start_trigger_loop)
+
+    ; The motor, trigger and display paths are now live. Audio is optional and
+    ; continues independently, so it must not delay the first valid command.
+    (setvar 'trigger_input_ready 1)
+    (debug_log "Startup: Trigger input ready")
 
     (state_transition_to STATE_OFF "startup" THREAD_STACK_STATE_TRANSITIONS state_handler_off) ; ***Start state machine running for first time
 

--- a/blacktip_dpv/blacktip_dpv.lisp
+++ b/blacktip_dpv/blacktip_dpv.lisp
@@ -890,14 +890,11 @@
 {
     (gpio-configure 'pin-ppm 'pin-mode-in-pd)
 
-    ; Sample before main advertises readiness. A released trigger is ready for
-    ; its first click; a held trigger remains blocked until it is released.
+    ; Sample before main advertises readiness, but keep the input disarmed.
+    ; main samples again after readiness before starting the state machine.
     (if (= 1 (gpio-read 'pin-ppm))
         (setvar 'sw_pressed 1)
         (setvar 'sw_pressed 0)
-    )
-    (if (= sw_pressed 0)
-        (setvar 'trigger_armed 1)
     )
 
     (loopwhile-thd THREAD_STACK_GPIO t {
@@ -2263,6 +2260,15 @@
     ; The motor, trigger and display paths are now live. Audio is optional and
     ; continues independently, so it must not delay the first valid command.
     (setvar 'trigger_input_ready 1)
+    ; Sample synchronously after readiness so a press that started before it
+    ; was published stays disarmed. The state machine starts only after this.
+    (if (= 1 (gpio-read 'pin-ppm))
+        (setvar 'sw_pressed 1)
+        (setvar 'sw_pressed 0)
+    )
+    (if (= sw_pressed 0)
+        (setvar 'trigger_armed 1)
+    )
     (debug_log "Startup: Trigger input ready")
 
     (state_transition_to STATE_OFF "startup" THREAD_STACK_STATE_TRANSITIONS state_handler_off) ; ***Start state machine running for first time

--- a/blacktip_dpv/blacktip_dpv.lisp
+++ b/blacktip_dpv/blacktip_dpv.lisp
@@ -132,6 +132,8 @@
 
 ; Masks for 0..8 LEDs lit (ordered per hardware bit mapping)
 (define TIMER_BAR_MASKS (list 0x00 0x40 0x60 0x70 0x78 0x7C 0x7E 0x7F 0xFF))
+(define TIMER_BAR_SOURCE_BITS (list 0x80 0x01 0x02 0x04 0x08 0x10 0x20 0x40))
+(define TIMER_BAR_ROTATION_2_BITS (list 0x40 0x20 0x10 0x08 0x04 0x02 0x01 0x80))
 
 ; EEPROM settings buffer size. Five-click shutdown is stored in slot 32.
 (define EEPROM_SETTINGS_COUNT 33)
@@ -1582,7 +1584,7 @@
     })
 })
 
-(defun apply_smart_cruise_timer_bar (pixbuf)
+(defun apply_smart_cruise_timer_bar (pixbuf frame_rotation)
 {
     ; Apply Smart Cruise timer bar to the bottom row when active
     ; The display buffer is organized as 8 rows of 2 bytes each (16 bytes total)
@@ -1600,9 +1602,32 @@
         ; Lookup table approach for clarity
         (var bottom_row_value (ix TIMER_BAR_MASKS (clamp leds_lit 0 8)))
 
-        ; Set the bottom row (byte 15) to show the timer bar
-        (var current_byte (bufget-u8 pixbuf 15))
-        (bufset-u8 pixbuf 15 (bitwise-or current_byte bottom_row_value))
+        ; The frame is pre-rotated before this overlay is applied. Rotate the
+        ; logical bottom-row bar by the same amount so it follows the display.
+        (cond
+            ((= frame_rotation 0) {
+                (var current_byte (bufget-u8 pixbuf 15))
+                (bufset-u8 pixbuf 15 (bitwise-or current_byte bottom_row_value))
+            })
+            ((= frame_rotation 1)
+                (looprange col 0 8
+                    (if (!= (bitwise-and bottom_row_value (ix TIMER_BAR_SOURCE_BITS col)) 0)
+                        (bufset-u8 pixbuf (+ (* col 2) 1)
+                            (bitwise-or (bufget-u8 pixbuf (+ (* col 2) 1)) 0x80)))))
+            ((= frame_rotation 2) {
+                (looprange col 0 8
+                    (if (!= (bitwise-and bottom_row_value (ix TIMER_BAR_SOURCE_BITS col)) 0)
+                        (bufset-u8 pixbuf 1
+                            (bitwise-or (bufget-u8 pixbuf 1) (ix TIMER_BAR_ROTATION_2_BITS col)))))
+            })
+            ((= frame_rotation 3)
+                (looprange col 0 8
+                    (if (!= (bitwise-and bottom_row_value (ix TIMER_BAR_SOURCE_BITS col)) 0)
+                        (bufset-u8 pixbuf (+ (* (- 7 col) 2) 1)
+                            (bitwise-or (bufget-u8 pixbuf (+ (* (- 7 col) 2) 1)) 0x40)))))
+            (t
+                (debug_log_format (str-merge "Display: Invalid rotation " (to-str frame_rotation) " for timer bar")))
+        )
     })
 
     leds_lit ; Return the LED count or -1
@@ -1732,7 +1757,7 @@
                 (bufcpy pixbuf 0 display_lut_bin (+ 8 start_pos) 16) ; copy the required display from binary LUT to "pixbuf"
             )
             ; Apply Smart Cruise timer bar overlay to bottom row if active
-            (apply_smart_cruise_timer_bar pixbuf)
+            (apply_smart_cruise_timer_bar pixbuf (if (= display_mpu_addr 0x70) rotation rotation2))
             (i2c-tx-rx display_mpu_addr pixbuf) ; send display characters
             (i2c-tx-rx display_mpu_addr (list 0x81)) ; Turn on display
             (setvar 'last_disp_num eff_disp)

--- a/blacktip_dpv/tests/run_tests.py
+++ b/blacktip_dpv/tests/run_tests.py
@@ -177,6 +177,11 @@ def trigger_arm_after_release(trigger_input_ready, sw_pressed, trigger_armed=0):
     return trigger_armed
 
 
+def trigger_initial_arm(sw_pressed):
+    """Mirror the synchronous GPIO sample before readiness is published."""
+    return 0 if sw_pressed == 1 else 1
+
+
 def migrate_eeprom_v3(eeprom, stored_version):
     """Mirror only the layered v3 migration relevant to an existing schema."""
     result = dict(eeprom)
@@ -817,6 +822,10 @@ def test_startup_trigger_readiness():
 
     assert_eq(trigger_click_accepted(0, 0, 1), False,
               "startup trigger: presses are ignored before readiness")
+    assert_eq(trigger_initial_arm(0), 1,
+              "startup trigger: an initially released trigger is armed")
+    assert_eq(trigger_initial_arm(1), 0,
+              "startup trigger: an initially held trigger remains blocked")
     assert_eq(trigger_arm_after_release(1, 1), 0,
               "startup trigger: a held trigger does not arm at readiness")
     assert_eq(trigger_click_accepted(1, 0, 1), False,
@@ -839,6 +848,10 @@ def test_startup_trigger_readiness():
     startup_tune_start = source.index('(spawn THREAD_STACK_CLICK_BEEP play_imperial_march)', main_start)
     assert_eq(trigger_loop_start < ready_start < state_machine_start < startup_tune_start, True,
               "startup trigger: readiness follows trigger setup but precedes optional audio")
+    trigger_function_start = source.index('(defun start_trigger_loop')
+    initial_gpio_sample = source.index("(gpio-read 'pin-ppm)", trigger_function_start)
+    assert_eq(initial_gpio_sample < ready_start, True,
+              "startup trigger: initial GPIO sample precedes readiness")
 
 
 def test_click_and_beep_regressions():

--- a/blacktip_dpv/tests/run_tests.py
+++ b/blacktip_dpv/tests/run_tests.py
@@ -140,6 +140,18 @@ def request_five_click_shutdown_simulate(state):
     return 0 if five_click_shutdown_rejection_reason(state) is not None else 1
 
 
+def trigger_click_accepted(trigger_input_ready, trigger_armed, sw_pressed):
+    """Mirror the stopped-state guard before beginning a click sequence."""
+    return trigger_input_ready == 1 and trigger_armed == 1 and sw_pressed == 1
+
+
+def trigger_arm_after_release(trigger_input_ready, sw_pressed, trigger_armed=0):
+    """Mirror the trigger loop's release-to-arm behaviour."""
+    if trigger_input_ready == 1 and sw_pressed == 0:
+        return 1
+    return trigger_armed
+
+
 def migrate_eeprom_v3(eeprom, stored_version):
     """Mirror only the layered v3 migration relevant to an existing schema."""
     result = dict(eeprom)
@@ -760,6 +772,35 @@ def test_five_click_shutdown_decision():
               "firmware guard: missing build component fails safe")
 
 
+def test_startup_trigger_readiness():
+    print("\n=== Testing startup trigger readiness ===")
+
+    assert_eq(trigger_click_accepted(0, 0, 1), False,
+              "startup trigger: presses are ignored before readiness")
+    assert_eq(trigger_arm_after_release(1, 1), 0,
+              "startup trigger: a held trigger does not arm at readiness")
+    assert_eq(trigger_click_accepted(1, 0, 1), False,
+              "startup trigger: held pre-ready press cannot start motor")
+    assert_eq(trigger_arm_after_release(1, 0), 1,
+              "startup trigger: release arms input after readiness")
+    assert_eq(trigger_click_accepted(1, 1, 1), True,
+              "startup trigger: new press after release is accepted")
+
+    source = (Path(__file__).resolve().parents[1] / 'blacktip_dpv.lisp').read_text()
+    state_off_start = source.index('(defun state_handler_off')
+    state_off_end = source.index('(defun smart_cruise_upgrade_if_needed', state_off_start)
+    state_off_source = source[state_off_start:state_off_end]
+    assert_eq('(and (= trigger_input_ready 1) (= trigger_armed 1) (= sw_pressed 1))' in state_off_source,
+              True, "startup trigger: stopped state requires ready and armed input")
+    main_start = source.index('(defun main')
+    trigger_loop_start = source.index('(start_trigger_loop)', main_start)
+    ready_start = source.index("(setvar 'trigger_input_ready 1)", main_start)
+    state_machine_start = source.index('(state_transition_to STATE_OFF "startup"', main_start)
+    startup_tune_start = source.index('(spawn THREAD_STACK_CLICK_BEEP play_imperial_march)', main_start)
+    assert_eq(trigger_loop_start < ready_start < state_machine_start < startup_tune_start, True,
+              "startup trigger: readiness follows trigger setup but precedes optional audio")
+
+
 def test_click_and_beep_regressions():
     print("\n=== Testing click and beep regressions ===")
     # Existing stopped-state actions: 1=no-op, 2=start, 3=jump, 4=untangle.
@@ -852,6 +893,7 @@ def run_all_tests():
     test_state_metrics_reset()
     test_five_click_settings_and_migration()
     test_five_click_shutdown_decision()
+    test_startup_trigger_readiness()
     test_click_and_beep_regressions()
 
     print("\n══════════════════════════════════════════")

--- a/blacktip_dpv/tests/run_tests.py
+++ b/blacktip_dpv/tests/run_tests.py
@@ -44,6 +44,9 @@ def assert_near(actual, expected, tolerance, test_name):
 SPEED_REVERSE_THRESHOLD = 5
 DISPLAY_LUT_PATH = Path(__file__).resolve().parents[1] / 'assets' / 'display_lut.csv'
 DISPLAY_LUT_HEADERS = ['index', 'name', 'rotation'] + [f'b{i}' for i in range(16)]
+TIMER_BAR_MASKS = [0x00, 0x40, 0x60, 0x70, 0x78, 0x7C, 0x7E, 0x7F, 0xFF]
+TIMER_BAR_SOURCE_BITS = [0x80, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40]
+TIMER_BAR_ROTATION_2_BITS = [0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01, 0x80]
 
 def clamp(value, min_val, max_val):
     """Clamp value between min and max"""
@@ -110,6 +113,28 @@ def rotate_display_clockwise(matrix):
     """Rotate a physical display matrix 90° clockwise."""
     return [[matrix[7 - column][row] for column in range(8)]
             for row in range(8)]
+
+
+def apply_timer_bar_overlay(frame_bytes, leds_lit, rotation):
+    """Mirror the rotation-aware Smart Cruise timer overlay."""
+    frame = list(frame_bytes)
+    mask = TIMER_BAR_MASKS[leds_lit]
+
+    if rotation == 0:
+        frame[15] |= mask
+    elif rotation == 1:
+        for column, source_bit in enumerate(TIMER_BAR_SOURCE_BITS):
+            if mask & source_bit:
+                frame[column * 2 + 1] |= 0x80
+    elif rotation == 2:
+        for column, source_bit in enumerate(TIMER_BAR_SOURCE_BITS):
+            if mask & source_bit:
+                frame[1] |= TIMER_BAR_ROTATION_2_BITS[column]
+    elif rotation == 3:
+        for column, source_bit in enumerate(TIMER_BAR_SOURCE_BITS):
+            if mask & source_bit:
+                frame[(7 - column) * 2 + 1] |= 0x40
+    return frame
 
 
 # Five-click shutdown mirrors. The third fw-ver value is the beta/test build;
@@ -304,6 +329,21 @@ def test_display_lut_structure_and_rotation():
               "display LUT: asymmetric fixture rotates clockwise")
     assert_eq(actual_clockwise == expected_counter_clockwise, False,
               "display LUT: asymmetric fixture rejects counter-clockwise rotation")
+
+
+def test_smart_cruise_timer_bar_rotation():
+    """The timer overlay must rotate with the pre-rotated display frame."""
+    print("\n=== Testing Smart Cruise timer bar rotation ===")
+
+    base_frame = [0] * 16
+    for leds_lit in range(9):
+        expected = physical_display_matrix(apply_timer_bar_overlay(base_frame, leds_lit, 0))
+        for rotation in range(4):
+            if rotation > 0:
+                expected = rotate_display_clockwise(expected)
+            actual = physical_display_matrix(apply_timer_bar_overlay(base_frame, leds_lit, rotation))
+            assert_eq(actual, expected,
+                      f"timer bar: {leds_lit} LEDs rotates clockwise at rotation {rotation}")
 
 # =============================================================================
 # New functions added in PR (VESC 7.00 compatibility)
@@ -884,6 +924,7 @@ def run_all_tests():
     test_speed_percentage_at()
     test_calculate_rpm()
     test_display_lut_structure_and_rotation()
+    test_smart_cruise_timer_bar_rotation()
     test_validate_lut_header()
     test_debug_log()
     test_debug_log_format()

--- a/blacktip_dpv/tests/run_tests.py
+++ b/blacktip_dpv/tests/run_tests.py
@@ -177,9 +177,9 @@ def trigger_arm_after_release(trigger_input_ready, sw_pressed, trigger_armed=0):
     return trigger_armed
 
 
-def trigger_initial_arm(sw_pressed):
-    """Mirror the synchronous GPIO sample before readiness is published."""
-    return 0 if sw_pressed == 1 else 1
+def trigger_arm_after_ready_sample(trigger_input_ready, sw_pressed):
+    """Mirror the synchronous sample that follows readiness publication."""
+    return 1 if trigger_input_ready == 1 and sw_pressed == 0 else 0
 
 
 def migrate_eeprom_v3(eeprom, stored_version):
@@ -822,10 +822,10 @@ def test_startup_trigger_readiness():
 
     assert_eq(trigger_click_accepted(0, 0, 1), False,
               "startup trigger: presses are ignored before readiness")
-    assert_eq(trigger_initial_arm(0), 1,
-              "startup trigger: an initially released trigger is armed")
-    assert_eq(trigger_initial_arm(1), 0,
-              "startup trigger: an initially held trigger remains blocked")
+    assert_eq(trigger_arm_after_ready_sample(1, 0), 1,
+              "startup trigger: a post-ready released trigger is armed")
+    assert_eq(trigger_arm_after_ready_sample(1, 1), 0,
+              "startup trigger: a post-ready held trigger remains blocked")
     assert_eq(trigger_arm_after_release(1, 1), 0,
               "startup trigger: a held trigger does not arm at readiness")
     assert_eq(trigger_click_accepted(1, 0, 1), False,
@@ -852,6 +852,9 @@ def test_startup_trigger_readiness():
     initial_gpio_sample = source.index("(gpio-read 'pin-ppm)", trigger_function_start)
     assert_eq(initial_gpio_sample < ready_start, True,
               "startup trigger: initial GPIO sample precedes readiness")
+    post_ready_gpio_sample = source.index("(gpio-read 'pin-ppm)", ready_start)
+    assert_eq(ready_start < post_ready_gpio_sample < state_machine_start, True,
+              "startup trigger: released input is armed from a post-ready sample")
 
 
 def test_click_and_beep_regressions():


### PR DESCRIPTION
- Ignore trigger input received before the DPV runtime is ready, and require a release before accepting the next click sequence.
- Rotate the Smart Cruise remaining-time bar with the selected display rotation.
- Bump the Blacktip DPV package version to 1.5.2.

## Testing

- `make test`
- `make`
- Confirmed the rotated Smart Cruise timer bar on Blacktip hardware.
